### PR TITLE
Add dependent packages from requirements to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.17
-pandas>=1.0.1
-# TODO: add version ranges for the following:
+pandas>=1.0.3
+pyarrow>=0.17.0
 regex
-pyarrow
 fastparquet
+# TODO: The following dependency should go away when we switch to Python 3.8.
 memoized-property
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+# read requirements from file
+with open('requirements.txt') as fh:
+    requirements = fh.read().splitlines()
+
 setuptools.setup(
     name="text_extensions_for_pandas",
     version="0.0.1_prealpha",
@@ -28,6 +32,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     # Note that this URL is where the project *will* be, not where it currently is.
     url="https://github.com/IBM/text-extensions-for-pandas",
+    install_requires=requirements,
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This adds dependent packages from requirements.txt to setup.py so that when the user installs, the required dependencies will be installed also.