### PR TITLE
Implement Arrow conversions for char and token span arrays

### DIFF
--- a/text_extensions_for_pandas/array/arrow_compat.py
+++ b/text_extensions_for_pandas/array/arrow_compat.py
@@ -49,24 +49,11 @@ class ArrowCharSpanType(pa.PyExtensionType):
         # Store target text as field metadata
         metadata = {self.TARGET_TEXT_KEY: target_text}
 
-        '''
-        fields = [
-            pa.field('CharSpan', pa.struct(data_fields), nullable=False, metadata=metadata)
-        ]
-        '''
         fields = [
             pa.field(self.BEGINS_NAME, index_dtype, metadata=metadata),
             pa.field(self.ENDS_NAME, index_dtype)
         ]
-        '''
-        data_fields = [
-            ('begin', pa.int32()),
-            ('end', pa.int32())
-        ]
-        fields = [Deserialize
-            ('CharSpan', pa.struct(data_fields))
-        ]
-        '''
+
         pa.PyExtensionType.__init__(self, pa.struct(fields))
 
     def __reduce__(self):
@@ -83,19 +70,6 @@ def char_span_to_arrow(char_span):
     :param char_span: A CharSpanArray to be converted
     :return: pyarrow.ExtensionArray containing CharSpan data
     """
-
-    # Store begins as an offset array, offset length is 1 more than value count
-    #offsets = np.append(self._begins, self._begins[-1])
-
-    '''
-    offsets = np.full(len(self._begins) + 1, len(self._text), dtype='int32')
-    offsets_buf = pa.py_buffer(offsets)
-
-    # Create string array for the target text
-    text_buf = pa.py_buffer(self._text.encode('utf-8'))
-    text_array = pa.Array.from_buffers(pa.string(), len(self._begins), [None, offsets_buf, text_buf])
-    '''
-
     # Create array for begins, ends
     begins_array = pa.array(char_span.begin)
     ends_array = pa.array(char_span.end)
@@ -104,9 +78,6 @@ def char_span_to_arrow(char_span):
     data_fields = list(typ.storage_type)
 
     storage = pa.StructArray.from_arrays([begins_array, ends_array], fields=data_fields)
-
-    #data_array = pa.StructArray.from_arrays([begins_array, ends_array], fields=data_fields)
-    #storage = pa.StructArray.from_arrays([data_array], fields=fields)
 
     return pa.ExtensionArray.from_storage(typ, storage)
 

--- a/text_extensions_for_pandas/array/arrow_conversion.py
+++ b/text_extensions_for_pandas/array/arrow_conversion.py
@@ -14,7 +14,7 @@
 #
 
 #
-# arrow_compat.py
+# arrow_conversion.py
 #
 # Part of text_extensions_for_pandas
 #
@@ -64,7 +64,7 @@ class ArrowCharSpanType(pa.PyExtensionType):
 
 class ArrowTokenSpanType(pa.PyExtensionType):
     """
-    PyArrow extension type definition for conversions to/from CharSpan columns
+    PyArrow extension type definition for conversions to/from TokenSpan columns
     """
 
     TARGET_TEXT_KEY = ArrowCharSpanType.TARGET_TEXT_KEY
@@ -73,7 +73,7 @@ class ArrowTokenSpanType(pa.PyExtensionType):
 
     def __init__(self, index_dtype, target_text):
         """
-        Create an instance of a CharSpan data type with given index type and
+        Create an instance of a TokenSpan data type with given index type and
         target text that will be stored in Field metadata.
 
         :param index_dtype:

--- a/text_extensions_for_pandas/array/char_span.py
+++ b/text_extensions_for_pandas/array/char_span.py
@@ -207,7 +207,7 @@ class CharSpanType(pd.api.extensions.ExtensionDtype):
         Convert the given extension array of type ArrowCharSpanType to a
         CharSpanArray.
         """
-        from text_extensions_for_pandas.array.arrow_compat import arrow_to_char_span
+        from text_extensions_for_pandas.array.arrow_conversion import arrow_to_char_span
         return arrow_to_char_span(extension_array)
 
 
@@ -698,5 +698,5 @@ class CharSpanArray(pd.api.extensions.ExtensionArray):
         :param type: Optional type passed to arrow for conversion, not used
         :return: pyarrow.ExtensionArray of type ArrowCharSpanType
         """
-        from text_extensions_for_pandas.array.arrow_compat import char_span_to_arrow
+        from text_extensions_for_pandas.array.arrow_conversion import char_span_to_arrow
         return char_span_to_arrow(self)

--- a/text_extensions_for_pandas/array/char_span.py
+++ b/text_extensions_for_pandas/array/char_span.py
@@ -178,7 +178,7 @@ class CharSpanType(pd.api.extensions.ExtensionDtype):
     @property
     def name(self) -> str:
         """A string representation of the dtype."""
-        return "CharSpan"
+        return "CharSpanType"
 
     @classmethod
     def construct_from_string(cls, string: str):
@@ -201,6 +201,14 @@ class CharSpanType(pd.api.extensions.ExtensionDtype):
         for information about this method.
         """
         return CharSpanArray
+
+    def __from_arrow__(self, extension_array):
+        """
+        Convert the given extension array of type ArrowCharSpanType to a
+        CharSpanArray.
+        """
+        from text_extensions_for_pandas.array.arrow_compat import arrow_to_char_span
+        return arrow_to_char_span(extension_array)
 
 
 class CharSpanArray(pd.api.extensions.ExtensionArray):
@@ -683,3 +691,12 @@ class CharSpanArray(pd.api.extensions.ExtensionArray):
         HTML pretty-printing of a series of spans for Jupyter notebooks.
         """
         return util.pretty_print_html(self)
+
+    def __arrow_array__(self, type=None):
+        """
+        Conversion of this Array to a pyarrow.ExtensionArray.
+        :param type: Optional type passed to arrow for conversion, not used
+        :return: pyarrow.ExtensionArray of type ArrowCharSpanType
+        """
+        from text_extensions_for_pandas.array.arrow_compat import char_span_to_arrow
+        return char_span_to_arrow(self)

--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -71,7 +71,7 @@ class TensorType(pd.api.extensions.ExtensionDtype):
         return TensorArray
 
     def __from_arrow__(self, extension_array):
-        from text_extensions_for_pandas.array.arrow_compat import ArrowTensorArray
+        from text_extensions_for_pandas.array.arrow_conversion import ArrowTensorArray
         values = ArrowTensorArray.to_numpy(extension_array)
         return TensorArray(values)
 
@@ -233,7 +233,7 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
             raise NotImplementedError(f"'{name}' aggregate not implemented.")
 
     def __arrow_array__(self, type=None):
-        from text_extensions_for_pandas.array.arrow_compat import ArrowTensorArray
+        from text_extensions_for_pandas.array.arrow_conversion import ArrowTensorArray
         return ArrowTensorArray.from_numpy(self._tensor)
 
 

--- a/text_extensions_for_pandas/array/test_char_span.py
+++ b/text_extensions_for_pandas/array/test_char_span.py
@@ -14,6 +14,8 @@
 #
 
 import numpy as np
+import os
+import tempfile
 import unittest
 
 from text_extensions_for_pandas.array.char_span import *
@@ -361,6 +363,19 @@ class CharSpanArrayTest(ArrayTestBase):
         self._assertArrayEquals(
             one_one_2_2.contains(CharSpan(test_text, 1, 1)), [True, False]
         )
+
+
+class CharSpanArrayIOTests(ArrayTestBase):
+
+    def test_feather(self):
+        arr = self._make_spans_of_tokens()
+        df = pd.DataFrame({'CharSpan': arr})
+
+        with tempfile.TemporaryDirectory() as dirpath:
+            filename = os.path.join(dirpath, 'char_span_array_test.feather')
+            df.to_feather(filename)
+            df_read = pd.read_feather(filename)
+            pd.testing.assert_frame_equal(df, df_read)
 
 
 if __name__ == "__main__":

--- a/text_extensions_for_pandas/array/test_token_span.py
+++ b/text_extensions_for_pandas/array/test_token_span.py
@@ -296,16 +296,34 @@ class TokenSpanArrayTest(ArrayTestBase):
 
 class TokenSpanArrayIOTests(ArrayTestBase):
 
-    def test_feather(self):
-        toks = self._make_spans_of_tokens()
-        s1 = TokenSpanArray(toks, [0, 1, 2, 3, 0, 2, 0], [1, 2, 3, 4, 2, 4, 4])
-        df = pd.DataFrame({'s1': s1})
-
+    def do_roundtrip(self, df):
         with tempfile.TemporaryDirectory() as dirpath:
             filename = os.path.join(dirpath, 'token_span_array_test.feather')
             df.to_feather(filename)
             df_read = pd.read_feather(filename)
             pd.testing.assert_frame_equal(df, df_read)
+
+    def test_feather(self):
+        toks = self._make_spans_of_tokens()
+
+        # Equal token spans to tokens
+        s0 = TokenSpanArray(toks, np.arange(len(toks)), np.arange(len(toks)) + 1)
+        df0 = pd.DataFrame({'s0': s0})
+        self.do_roundtrip(df0)
+
+        # More token spans than tokens
+        s1 = TokenSpanArray(toks, [0, 1, 2, 3, 0, 2, 0], [1, 2, 3, 4, 2, 4, 4])
+        df1 = pd.DataFrame({'s1': s1})
+        self.do_roundtrip(df1)
+
+        # Less token spans than tokens
+        s2 = TokenSpanArray(toks, [0, 3], [3, 4])
+        df2 = pd.DataFrame({'s2': s2})
+        self.do_roundtrip(df2)
+
+        df = pd.concat([df0, df1, df2], axis=1)
+        self.do_roundtrip(df)
+        x = 10
 
 
 if __name__ == "__main__":

--- a/text_extensions_for_pandas/array/test_token_span.py
+++ b/text_extensions_for_pandas/array/test_token_span.py
@@ -14,6 +14,8 @@
 #
 
 import numpy as np
+import os
+import tempfile
 import unittest
 
 from text_extensions_for_pandas.array.test_char_span import ArrayTestBase
@@ -290,6 +292,19 @@ class TokenSpanArrayTest(ArrayTestBase):
             df.columns, ["begin", "end", "begin_token", "end_token", "covered_text"]
         )
         self.assertEqual(len(df), len(arr))
+
+
+class TokenSpanArrayIOTests(ArrayTestBase):
+
+    def test_feather(self):
+        arr = self._make_spans_of_tokens()
+        df = pd.DataFrame({'TokenSpan': arr})
+
+        with tempfile.TemporaryDirectory() as dirpath:
+            filename = os.path.join(dirpath, 'token_span_array_test.feather')
+            df.to_feather(filename)
+            df_read = pd.read_feather(filename)
+            pd.testing.assert_frame_equal(df, df_read)
 
 
 if __name__ == "__main__":

--- a/text_extensions_for_pandas/array/test_token_span.py
+++ b/text_extensions_for_pandas/array/test_token_span.py
@@ -297,8 +297,9 @@ class TokenSpanArrayTest(ArrayTestBase):
 class TokenSpanArrayIOTests(ArrayTestBase):
 
     def test_feather(self):
-        arr = self._make_spans_of_tokens()
-        df = pd.DataFrame({'TokenSpan': arr})
+        toks = self._make_spans_of_tokens()
+        s1 = TokenSpanArray(toks, [0, 1, 2, 3, 0, 2, 0], [1, 2, 3, 4, 2, 4, 4])
+        df = pd.DataFrame({'s1': s1})
 
         with tempfile.TemporaryDirectory() as dirpath:
             filename = os.path.join(dirpath, 'token_span_array_test.feather')

--- a/text_extensions_for_pandas/array/test_token_span.py
+++ b/text_extensions_for_pandas/array/test_token_span.py
@@ -307,23 +307,33 @@ class TokenSpanArrayIOTests(ArrayTestBase):
         toks = self._make_spans_of_tokens()
 
         # Equal token spans to tokens
-        s0 = TokenSpanArray(toks, np.arange(len(toks)), np.arange(len(toks)) + 1)
-        df0 = pd.DataFrame({'s0': s0})
-        self.do_roundtrip(df0)
-
-        # More token spans than tokens
-        s1 = TokenSpanArray(toks, [0, 1, 2, 3, 0, 2, 0], [1, 2, 3, 4, 2, 4, 4])
-        df1 = pd.DataFrame({'s1': s1})
+        ts1 = TokenSpanArray(toks, np.arange(len(toks)), np.arange(len(toks)) + 1)
+        df1 = pd.DataFrame({"ts1": ts1})
         self.do_roundtrip(df1)
 
-        # Less token spans than tokens
-        s2 = TokenSpanArray(toks, [0, 3], [3, 4])
-        df2 = pd.DataFrame({'s2': s2})
+        # More token spans than tokens
+        ts2 = TokenSpanArray(toks, [0, 1, 2, 3, 0, 2, 0], [1, 2, 3, 4, 2, 4, 4])
+        df2 = pd.DataFrame({"ts2": ts2})
         self.do_roundtrip(df2)
 
-        df = pd.concat([df0, df1, df2], axis=1)
+        # Less token spans than tokens, 2 splits no padding
+        ts3 = TokenSpanArray(toks, [0, 3], [3, 4])
+        df3 = pd.DataFrame({"ts3": ts3})
+        self.do_roundtrip(df3)
+
+        # Less token spans than tokens, 1 split with padding
+        ts4 = TokenSpanArray(toks, [0, 2, 3], [2, 3, 4])
+        df4 = pd.DataFrame({"ts4": ts4})
+        self.do_roundtrip(df4)
+
+        # With a CharSpan column, TokenSpan padded to same length
+        df5 = pd.DataFrame({"cs": toks})
+        df5 = pd.concat([df3, df5], axis=1)
+        self.do_roundtrip(df5)
+
+        # All columns together, TokenSpan arrays padded as needed
+        df = pd.concat([df1, df2, df3, df4], axis=1)
         self.do_roundtrip(df)
-        x = 10
 
 
 if __name__ == "__main__":

--- a/text_extensions_for_pandas/array/token_span.py
+++ b/text_extensions_for_pandas/array/token_span.py
@@ -197,13 +197,13 @@ class TokenSpanType(CharSpanType):
 
     @property
     def type(self):
-        # The type for a single row of a column of type CharSpan
+        # The type for a single row of a column of type TokenSpan
         return TokenSpan
 
     @property
     def name(self) -> str:
         """:return: A string representation of the dtype."""
-        return "CharSpan"
+        return "TokenSpanType"
 
     @classmethod
     def construct_array_type(cls):
@@ -212,6 +212,14 @@ class TokenSpanType(CharSpanType):
         for information about this method.
         """
         return TokenSpanArray
+
+    def __from_arrow__(self, extension_array):
+        """
+        Convert the given extension array of type ArrowTokenSpanType to a
+        TokenSpanArray.
+        """
+        from text_extensions_for_pandas.array.arrow_compat import arrow_to_token_span
+        return arrow_to_token_span(extension_array)
 
 
 class TokenSpanArray(CharSpanArray):
@@ -772,3 +780,12 @@ class TokenSpanArray(CharSpanArray):
             if hasattr(self, attr_name):
                 delattr(self, attr_name)
         self._hash = None
+
+    def __arrow_array__(self, type=None):
+        """
+        Conversion of this Array to a pyarrow.ExtensionArray.
+        :param type: Optional type passed to arrow for conversion, not used
+        :return: pyarrow.ExtensionArray of type ArrowTokenSpanType
+        """
+        from text_extensions_for_pandas.array.arrow_compat import token_span_to_arrow
+        return token_span_to_arrow(self)

--- a/text_extensions_for_pandas/array/token_span.py
+++ b/text_extensions_for_pandas/array/token_span.py
@@ -218,7 +218,7 @@ class TokenSpanType(CharSpanType):
         Convert the given extension array of type ArrowTokenSpanType to a
         TokenSpanArray.
         """
-        from text_extensions_for_pandas.array.arrow_compat import arrow_to_token_span
+        from text_extensions_for_pandas.array.arrow_conversion import arrow_to_token_span
         return arrow_to_token_span(extension_array)
 
 
@@ -787,5 +787,5 @@ class TokenSpanArray(CharSpanArray):
         :param type: Optional type passed to arrow for conversion, not used
         :return: pyarrow.ExtensionArray of type ArrowTokenSpanType
         """
-        from text_extensions_for_pandas.array.arrow_compat import token_span_to_arrow
+        from text_extensions_for_pandas.array.arrow_conversion import token_span_to_arrow
         return token_span_to_arrow(self)


### PR DESCRIPTION
Add Arrow conversions to/from char and token span arrays to enable saving DataFrames with these columns to feather files. This first implementation is not optimized for storage space and will save target text in the field metadata, possibly duplicated. Also, TokenSpanArrays will save a duplicate of the dependent CharSpanArrays in the same struct column. These could be improved in followup changes.