### PR TITLE
Fix for TensorArray slices that are empty

### DIFF
--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -103,18 +103,18 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
     Each tensor must have the same shape.
     """
 
-    def __init__(self, values: Union[np.ndarray, Iterable[np.ndarray]],
+    def __init__(self, values: Union[np.ndarray, Sequence[np.ndarray]],
                  make_contiguous: bool = True):
         """
         :param values: A `numpy.ndarray` or sequence of `numpy.ndarray`s of equal shape.
         :param make_contiguous: force values to be contiguous in memory
         """
-        if isinstance(values, Iterable):
-            self._tensor = np.stack(values, axis=0)
-        elif isinstance(values, np.ndarray):
+        if isinstance(values, np.ndarray):
             self._tensor = values
+        elif isinstance(values, Sequence):
+            self._tensor = np.stack(values, axis=0) if len(values) > 0 else np.array([])
         else:
-            raise TypeError(f"Expected a numpy.ndarray or list of numpy.ndarray, "
+            raise TypeError(f"Expected a numpy.ndarray or sequence of numpy.ndarray, "
                             f"but received {values} "
                             f"of type '{type(values)}' instead.")
         

--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -195,13 +195,11 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         for information about this method.
         """
         # TODO pandas converts series with np.asarray, then applied a function e.g. map_infer(array, is_float) to format strings etc.
-        # For empty or single element return np.ndarray, if slice has multiple
-        # elements return TensorArray of slice
+        # Return an ndarray for scalar item, or TensorArray for slice
         if isinstance(item, int):
             return self._tensor[item]
         else:
-            values = self._tensor[item]
-            return values if len(values) <= 1 else TensorArray(values)
+            return TensorArray(self._tensor[item])
 
     def __setitem__(self, key: Union[int, np.ndarray], value: Any) -> None:
         """

--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -195,11 +195,13 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         for information about this method.
         """
         # TODO pandas converts series with np.asarray, then applied a function e.g. map_infer(array, is_float) to format strings etc.
-        # If single element return as np.ndarray, if slice return TensorArray of slice
+        # For empty or single element return np.ndarray, if slice has multiple
+        # elements return TensorArray of slice
         if isinstance(item, int):
             return self._tensor[item]
         else:
-            return TensorArray(self._tensor[item])
+            values = self._tensor[item]
+            return values if len(values) <= 1 else TensorArray(values)
 
     def __setitem__(self, key: Union[int, np.ndarray], value: Any) -> None:
         """

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -207,6 +207,25 @@ class TestTensor(unittest.TestCase):
         expected = np.array([[3, 4], [5, 6]])
         npt.assert_array_equal(expected, result)
 
+    def test_bool_indexing(self):
+        s = TensorArray([[1, 2], [3, 4]])
+
+        result = s[[True, True]]
+        expected = np.array([[1, 2], [3, 4]])
+        npt.assert_array_equal(result, expected)
+
+        result = s[[True, False]]
+        expected = np.array([[1, 2]])
+        npt.assert_array_equal(result, expected)
+
+        result = s[[False, True]]
+        expected = np.array([[3, 4]])
+        npt.assert_array_equal(result, expected)
+
+        result = s[[False, False]]
+        expected = np.empty((0, 2))
+        npt.assert_array_equal(result, expected)
+
     def test_asarray(self):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         s = TensorArray(x)

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -42,6 +42,12 @@ class TestTensor(unittest.TestCase):
         s = TensorArray(x)
         self.assertEqual(len(s), 5)
 
+        x = np.empty((0, 2))
+        s = TensorArray(x)
+        self.assertEqual(len(s), 0)
+        s = TensorArray([])
+        self.assertEqual(len(s), 0)
+
         x = [np.ones([2, 3]), np.ones([3, 2])]
         with self.assertRaises(ValueError):
             TensorArray(x)
@@ -273,6 +279,29 @@ class TensorArrayDataFrameTests(unittest.TestCase):
                 c    [[3, 3], [3, 3]]"""
             ),
         )
+
+    def test_bool_indexing(self):
+        s = TensorArray([[1, 2], [3, 4]])
+        df = pd.DataFrame({
+            "col1": s
+        })
+        result = df[[False, False]]
+        self.assertEqual(len(result), 0)
+
+        result = df[[True, True]]
+        pd.testing.assert_frame_equal(result, df)
+
+        result = df[[True, False]]
+        self.assertTrue(isinstance(result, pd.DataFrame))
+        self.assertEqual(len(result), 1)
+        expected = df.iloc[[0]]
+        pd.testing.assert_frame_equal(result, expected)
+
+        result = df[[False, True]]
+        self.assertTrue(isinstance(result, pd.DataFrame))
+        self.assertEqual(len(result), 1)
+        expected = df.iloc[[1]]
+        pd.testing.assert_frame_equal(result, expected)
 
 
 class TensorArrayIOTests(unittest.TestCase):

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -217,18 +217,22 @@ class TestTensor(unittest.TestCase):
         s = TensorArray([[1, 2], [3, 4]])
 
         result = s[[True, True]]
+        self.assertTrue(isinstance(result, TensorArray))
         expected = np.array([[1, 2], [3, 4]])
         npt.assert_array_equal(result, expected)
 
         result = s[[True, False]]
+        self.assertTrue(isinstance(result, np.ndarray))
         expected = np.array([[1, 2]])
         npt.assert_array_equal(result, expected)
 
         result = s[[False, True]]
+        self.assertTrue(isinstance(result, np.ndarray))
         expected = np.array([[3, 4]])
         npt.assert_array_equal(result, expected)
 
         result = s[[False, False]]
+        self.assertTrue(isinstance(result, np.ndarray))
         expected = np.empty((0, 2))
         npt.assert_array_equal(result, expected)
 
@@ -280,15 +284,17 @@ class TensorArrayDataFrameTests(unittest.TestCase):
             ),
         )
 
-    def test_bool_indexing(self):
+    def test_bool_indexing_dataframe(self):
         s = TensorArray([[1, 2], [3, 4]])
         df = pd.DataFrame({
             "col1": s
         })
         result = df[[False, False]]
+        self.assertTrue(isinstance(result, pd.DataFrame))
         self.assertEqual(len(result), 0)
 
         result = df[[True, True]]
+        self.assertTrue(isinstance(result, pd.DataFrame))
         pd.testing.assert_frame_equal(result, df)
 
         result = df[[True, False]]
@@ -302,6 +308,27 @@ class TensorArrayDataFrameTests(unittest.TestCase):
         self.assertEqual(len(result), 1)
         expected = df.iloc[[1]]
         pd.testing.assert_frame_equal(result, expected)
+
+    def test_bool_indexing_series(self):
+        s = pd.Series(TensorArray([[1, 2], [3, 4]]))
+        result = s[[False, False]]
+        self.assertEqual(len(result), 0)
+
+        result = s[[True, True]]
+        self.assertTrue(isinstance(result, pd.Series))
+        pd.testing.assert_series_equal(result, s)
+
+        result = s[[True, False]]
+        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertEqual(len(result), 1)
+        expected = s.iloc[[0]]
+        np.testing.assert_array_equal(result, expected)
+
+        result = s[[False, True]]
+        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertEqual(len(result), 1)
+        expected = s.iloc[[1]]
+        np.testing.assert_array_equal(result, expected)
 
 
 class TensorArrayIOTests(unittest.TestCase):

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -206,10 +206,12 @@ class TestTensor(unittest.TestCase):
         s = TensorArray(x)
 
         result = s[1]
+        self.assertTrue(isinstance(result, np.ndarray))
         expected = np.array([3, 4])
         npt.assert_array_equal(expected, result)
 
         result = s[1:3]
+        self.assertTrue(isinstance(result, TensorArray))
         expected = np.array([[3, 4], [5, 6]])
         npt.assert_array_equal(expected, result)
 
@@ -219,22 +221,22 @@ class TestTensor(unittest.TestCase):
         result = s[[True, True]]
         self.assertTrue(isinstance(result, TensorArray))
         expected = np.array([[1, 2], [3, 4]])
-        npt.assert_array_equal(result, expected)
+        npt.assert_array_equal(result.to_numpy(), expected)
 
         result = s[[True, False]]
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTrue(isinstance(result, TensorArray))
         expected = np.array([[1, 2]])
-        npt.assert_array_equal(result, expected)
+        npt.assert_array_equal(result.to_numpy(), expected)
 
         result = s[[False, True]]
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTrue(isinstance(result, TensorArray))
         expected = np.array([[3, 4]])
-        npt.assert_array_equal(result, expected)
+        npt.assert_array_equal(result.to_numpy(), expected)
 
         result = s[[False, False]]
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTrue(isinstance(result, TensorArray))
         expected = np.empty((0, 2))
-        npt.assert_array_equal(result, expected)
+        npt.assert_array_equal(result.to_numpy(), expected)
 
     def test_asarray(self):
         x = np.array([[1, 2], [3, 4], [5, 6]])
@@ -312,6 +314,7 @@ class TensorArrayDataFrameTests(unittest.TestCase):
     def test_bool_indexing_series(self):
         s = pd.Series(TensorArray([[1, 2], [3, 4]]))
         result = s[[False, False]]
+        self.assertTrue(isinstance(result, pd.Series))
         self.assertEqual(len(result), 0)
 
         result = s[[True, True]]
@@ -319,16 +322,16 @@ class TensorArrayDataFrameTests(unittest.TestCase):
         pd.testing.assert_series_equal(result, s)
 
         result = s[[True, False]]
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTrue(isinstance(result, pd.Series))
         self.assertEqual(len(result), 1)
         expected = s.iloc[[0]]
-        np.testing.assert_array_equal(result, expected)
+        pd.testing.assert_series_equal(result, expected)
 
         result = s[[False, True]]
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTrue(isinstance(result, pd.Series))
         self.assertEqual(len(result), 1)
         expected = s.iloc[[1]]
-        np.testing.assert_array_equal(result, expected)
+        pd.testing.assert_series_equal(result, expected)
 
 
 class TensorArrayIOTests(unittest.TestCase):

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -213,7 +213,7 @@ class TestTensor(unittest.TestCase):
         result = s[1:3]
         self.assertTrue(isinstance(result, TensorArray))
         expected = np.array([[3, 4], [5, 6]])
-        npt.assert_array_equal(expected, result)
+        npt.assert_array_equal(expected, result.to_numpy())
 
     def test_bool_indexing(self):
         s = TensorArray([[1, 2], [3, 4]])


### PR DESCRIPTION
TensorArray slices that are empty have to be handled differently to return an empty np.array

Fixes #16 