### PR TITLE
Added workaround to avoid double dollar signs not rendering properly

### DIFF
--- a/text_extensions_for_pandas/test_util.py
+++ b/text_extensions_for_pandas/test_util.py
@@ -34,7 +34,7 @@ class UtilTest(TestBase):
     def test_pretty_print_html(self):
         self.maxDiff = None
         html = pretty_print_html(_TEST_TOKS["token_span"].values)
-        suffix = html[-796:]
+        suffix = html[-809:]
         # print(f"[[[{suffix}]]]")
         self.assertEqual(
             suffix,
@@ -56,7 +56,7 @@ class UtilTest(TestBase):
          style="float:right; background-color:#F5F5F5; border: 1px solid #E0E0E0; width: 60%;">
             <div style="float:center; padding:10px">
                 <p style="font-family:monospace">
-                    <span style="background-color:yellow">Item&#39;s</span> <span style="background-color:yellow">for</span> <span style="background-color:yellow">&lt;</span> <span style="background-color:yellow">&#36;100</span> <span style="background-color:yellow">&amp;</span> <span style="background-color:yellow">change
+                    <span style="background-color:yellow">Item&#39;s</span> <span style="background-color:yellow">for</span> <span style="background-color:yellow">&lt;</span> <span style="background-color:yellow"><span>&#36;</span>100</span> <span style="background-color:yellow">&amp;</span> <span style="background-color:yellow">change
                 </p>
             </div>
         </div>

--- a/text_extensions_for_pandas/util.py
+++ b/text_extensions_for_pandas/util.py
@@ -62,7 +62,8 @@ def pretty_print_html(column: Union["CharSpanArray", "TokenSpanArray"]) -> str:
             text_pieces.append("&#39;")
         elif text[i] == "$":
             # Dollar sign messes up Jupyter's JavaScript UI.
-            text_pieces.append("&#36;")
+            # Use backslash to avoid
+            text_pieces.append("<span>&#36;</span>")
         else:
             text_pieces.append(text[i])
 

--- a/text_extensions_for_pandas/util.py
+++ b/text_extensions_for_pandas/util.py
@@ -62,7 +62,7 @@ def pretty_print_html(column: Union["CharSpanArray", "TokenSpanArray"]) -> str:
             text_pieces.append("&#39;")
         elif text[i] == "$":
             # Dollar sign messes up Jupyter's JavaScript UI.
-            # Use backslash to avoid
+            # Place dollar sign in its own sub-span to avoid being misinterpeted as a LaTeX delimiter
             text_pieces.append("<span>&#36;</span>")
         else:
             text_pieces.append(text[i])


### PR DESCRIPTION
Bug fix for issue #31 
Avoids the issue where double dollar signs inside of text are interpreted by the math rendering system built into Jupyter as LaTeX inline math delimiters, causing improper rendering of text. @frreiss 