### PR TITLE
Refactor environment setup code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# vim swap files
+*.swp
+
 ibm-notebooks
 # PyCharm
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 install:
 #install conda
  - sudo apt-get update
- - sudo apt-get -y upgrade
  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
  - bash miniconda.sh -b -p $HOME/miniconda
  - source "$HOME/miniconda/etc/profile.d/conda.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ install:
 
 
 script:
+ - conda activate pd
  - python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
  - conda info -a
 
- - ./env.sh
+ - CONDA_HOME="${HOME}/miniconda" ./env.sh
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
 -
 install:
 #install conda
- - sudo apt update
+ - sudo apt-get update
+ - sudo apt-get -y upgrade
  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
  - bash miniconda.sh -b -p $HOME/miniconda
  - source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -14,13 +15,7 @@ install:
 
  - conda info -a
 
- - conda create --name pd
- - conda activate pd
- - conda env update -f environment.yml
-
- - pip install -r requirements.txt
- - python -m spacy download en_core_web_sm
- - pip install transformers
+ - ./env.sh
 
 
 script:

--- a/config/dev_env.yml
+++ b/config/dev_env.yml
@@ -1,10 +1,9 @@
-name: pd
+# Anaconda YAML file specifying packages that this project's build/test
+# environment should install from Anaconda's main channel.
 channels:
   - defaults
-  - conda-forge
 dependencies:
  - tensorflow
- - jupyterlab
  - pandas
  - regex
  - matplotlib
@@ -13,10 +12,5 @@ dependencies:
  - pytorch
  - black
  - scikit-learn 
- - spacy
- - pyarrow
- - fastparquet 
- - plotly
- - ipywidgets
 
 

--- a/config/dev_env_forge.yml
+++ b/config/dev_env_forge.yml
@@ -1,0 +1,13 @@
+# Anaconda YAML file specifying packages that this project's build/test
+# environment should install from Anaconda's "conda-forge" channel.
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+ - spacy
+ - pyarrow
+ - fastparquet 
+ - plotly
+ - ipywidgets
+
+

--- a/config/dev_reqs.txt
+++ b/config/dev_reqs.txt
@@ -1,0 +1,11 @@
+# dev_reqs.txt
+# Pips requirements file containing libraries needed for development and
+# testing of this project, but not strictly necessary at runtime 
+# NOTE: These requirements are IN ADDITION TO the packages in
+# config/dev_env.yml and requirements.txt
+pyyaml
+transformers
+spacy
+fastparquet
+
+

--- a/config/jupyter_reqs.txt
+++ b/config/jupyter_reqs.txt
@@ -1,0 +1,8 @@
+# jupyter_reqs.txt
+# Pip requirements file to create a Jupyterlab environment for development of
+# this project.
+jupyterlab
+nodejs
+xeus-python
+ipywidgets
+

--- a/env.sh
+++ b/env.sh
@@ -46,55 +46,37 @@ echo "Creating an Anaconda environment called '${ENV_NAME}'"
 # Remove the detrius of any previous runs of this script
 conda env remove -n ${ENV_NAME}
 
-
 conda create -y --name ${ENV_NAME} python=${PYTHON_VERSION}
+
+################################################################################
+# Preferred way to install packages: Anaconda main
+#
+# We use YAML files to ensure that the CI environment will use the same
+# configuration.
+conda env update -n ${ENV_NAME} -f config/dev_env.yml
+
+################################################################################
+# Second-best way to install packages: pip
+
+# All the installation steps that follow must be done from within the new
+# environment.
 conda activate ${ENV_NAME}
-
-################################################################################
-# set up conda environment as much as possible from environment.yml file
-
-conda env update -f environment.yml
-
-
-# Post-install steps for ipywidgets on JupyterLab require Node
-conda install -y -c conda-forge \
-    nodejs
-
-# Jupyter debugger requires the xeus-python kernel
-conda install -y -c conda-forge \
-    xeus-python
-
-
-################################################################################
-# Third-best way to install packages: pip
 
 # pip install with the project's requirements.txt so that any hard constraints
 # on package versions are respected in the created environment.
 pip install -r requirements.txt
 
-# memoized-property now installed from requirements.txt, so no need to pip 
-# intall it here.
-#pip install memoized-property
+# Additional layer of pip-installed stuff for running regression tests
+pip install -r config/dev_reqs.txt
 
-# Watson tooling requires pyyaml to be installed this way.
-pip install pyyaml
-
-# Huggingface transformers library is currently only on PyPI
-pip install transformers
+# Additional layer of pip-installed stuff for running notebooks
+pip install -r config/jupyter_reqs.txt
 
 ################################################################################
 # Least-preferred install method: Custom
 
 # spaCy language models for English
 python -m spacy download en_core_web_sm
-
-# Plotly for JupyterLab
-# Currently disabled because the install takes 5-10 minutes. 
-#echo "Not installing jupyterlab-plotly because the install takes 5-10 minutes."
-#echo "To install manually, activate the '${ENV_NAME}' environment and run the "
-#echo "following command:"
-#echo "   jupyter labextension install jupyterlab-plotly"
-#jupyter labextension install jupyterlab-plotly
 
 # Finish installation of ipywidgets from the "conda-forge" section above
 jupyter nbextension enable --py widgetsnbextension
@@ -106,6 +88,8 @@ jupyter labextension install @jupyterlab/toc
 # Jupyter debugger extension (requires xeus-python, installed above)
 jupyter labextension install @jupyterlab/debugger
 
+# Uncomment the following line if one of the "jupyter labextension install"
+# commands neglects to rebuild jupyterlab assets.
 #jupyter lab build
 
 conda deactivate


### PR DESCRIPTION
This PR refactors the Anaconda environment setup code in `env.sh` so that the environment will be the same between developers' machines and Travis CI runs. I have moved all the lists of dependencies for development, testing, and Jupyter into config files (commit 38f6e7a). I have also updated the Travis config file so that it uses `env.sh` to build the local environment (commit 905ae63). I may back out of that change if Travis has trouble testing this PR.

I also modified `.gitignore` so that Vim swap files won't get picked up by `git status` (commit 78dc08c)