### PR TITLE
Update BERT tokenizer integration to reflect API changes in Transformers library

### DIFF
--- a/config/dev_reqs.txt
+++ b/config/dev_reqs.txt
@@ -4,7 +4,7 @@
 # NOTE: These requirements are IN ADDITION TO the packages in
 # config/dev_env.yml and requirements.txt
 pyyaml
-transformers
+transformers>=3.0.0
 spacy
 fastparquet
 

--- a/text_extensions_for_pandas/io/tokenization.py
+++ b/text_extensions_for_pandas/io/tokenization.py
@@ -49,7 +49,7 @@ def make_bert_tokens(target_text: str, tokenizer) -> pd.DataFrame:
      * "special_tokens_mask": `True` if the token is a zero-length special token
        such as "start of document"
     """
-    from transformers.tokenization_utils import PreTrainedTokenizerFast
+    from transformers import PreTrainedTokenizerFast
 
     if not isinstance(tokenizer, PreTrainedTokenizerFast):
         raise TypeError(


### PR DESCRIPTION
The latest version of the [Transformers library](https://huggingface.co/transformers/) moved the `PreTrainedTokenizerFast` class to a new location within the package. This change breaks our integration with that project's tokenizer.

This PR updates the `import` statement to use the new location of `PreTrainedTokenizerFast`. I have also modified `dev_reqs.txt` to specify version 3.0.0 or greater of `transformers`.

@BryanCutler @xuhdev @ZachEichen you will want to rerun `env.sh` or manually upgrade your local copy of the `transformers` Python library after this PR is merged.