### PR TITLE
Fix tests again

### DIFF
--- a/config/dev_reqs.txt
+++ b/config/dev_reqs.txt
@@ -5,7 +5,8 @@
 # config/dev_env.yml and requirements.txt
 pyyaml
 transformers>=3.0.0
-spacy
+# SpaCy models aren't stable across point releases
+spacy==2.3.2
 fastparquet
 sphinx
 

--- a/text_extensions_for_pandas/io/test_conll.py
+++ b/text_extensions_for_pandas/io/test_conll.py
@@ -50,11 +50,9 @@ class CoNLLTest(unittest.TestCase):
             textwrap.dedent(
                 """\
                                     token_span ent_type
-                0           [4, 11): 'Bermuda'      ORG
-                1         [12, 20): 'Triangle'  PRODUCT
-                2           [61, 67): 'Alaska'      GPE
-                3      [73, 84): 'Santa Claus'   PERSON
-                4  [100, 113): 'Steven Wright'   PERSON"""
+                0           [61, 67): 'Alaska'      GPE
+                1      [73, 84): 'Santa Claus'   PERSON
+                2  [100, 113): 'Steven Wright'   PERSON"""
             ),
         )
 

--- a/text_extensions_for_pandas/io/test_spacy.py
+++ b/text_extensions_for_pandas/io/test_spacy.py
@@ -62,9 +62,9 @@ class IOTest(unittest.TestCase):
                 """\
                 [(0, 0, [0, 3): 'She', [0, 3): 'She', '-PRON-', 'PRON', 'PRP', 'nsubj', 1, 'Xxx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.')
                  (1, 1, [4, 8): 'sold', [4, 8): 'sold', 'sell', 'VERB', 'VBD', 'ROOT', 1, 'xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.')
-                 (2, 2, [9, 10): 'c', [9, 10): 'c', 'c', 'NOUN', 'NN', 'compound', 3, 'x', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.')
+                 (2, 2, [9, 10): 'c', [9, 10): 'c', 'c', 'NOUN', 'NN', 'det', 3, 'x', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.')
                  (3, 3, [11, 17): 'shills', [11, 17): 'shills', 'shill', 'NOUN', 'NNS', 'dobj', 1, 'xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.')
-                 (4, 4, [18, 20): 'by', [18, 20): 'by', 'by', 'ADP', 'IN', 'prep', 1, 'xx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.')
+                 (4, 4, [18, 20): 'by', [18, 20): 'by', 'by', 'ADP', 'IN', 'prep', 3, 'xx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.')
                  (5, 5, [21, 24): 'the', [21, 24): 'the', 'the', 'DET', 'DT', 'det', 7, 'xxx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.')
                  (6, 6, [25, 29): 'Sith', [25, 29): 'Sith', 'Sith', 'PROPN', 'NNP', 'compound', 7, 'Xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.')
                  (7, 7, [30, 34): 'Lord', [30, 34): 'Lord', 'Lord', 'PROPN', 'NNP', 'pobj', 4, 'Xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.')
@@ -83,9 +83,9 @@ class IOTest(unittest.TestCase):
                 """\
                 [(0, 0, [0, 3): 'She', [0, 3): 'She', '-PRON-', 'PRON', 'PRP', 'nsubj', 1, 'Xxx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.', <NA>, 1)
                  (1, 1, [4, 8): 'sold', [4, 8): 'sold', 'sell', 'VERB', 'VBD', 'ROOT', 1, 'xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.', 0, 2)
-                 (2, 2, [9, 10): 'c', [9, 10): 'c', 'c', 'NOUN', 'NN', 'compound', 3, 'x', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.', 1, 3)
+                 (2, 2, [9, 10): 'c', [9, 10): 'c', 'c', 'NOUN', 'NN', 'det', 3, 'x', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.', 1, 3)
                  (3, 3, [11, 17): 'shills', [11, 17): 'shills', 'shill', 'NOUN', 'NNS', 'dobj', 1, 'xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.', 2, 4)
-                 (4, 4, [18, 20): 'by', [18, 20): 'by', 'by', 'ADP', 'IN', 'prep', 1, 'xx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.', 3, 5)
+                 (4, 4, [18, 20): 'by', [18, 20): 'by', 'by', 'ADP', 'IN', 'prep', 3, 'xx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.', 3, 5)
                  (5, 5, [21, 24): 'the', [21, 24): 'the', 'the', 'DET', 'DT', 'det', 7, 'xxx', 'O', '',  True,  True, [0, 35): 'She sold c shills by the Sith Lord.', 4, 6)
                  (6, 6, [25, 29): 'Sith', [25, 29): 'Sith', 'Sith', 'PROPN', 'NNP', 'compound', 7, 'Xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.', 5, 7)
                  (7, 7, [30, 34): 'Lord', [30, 34): 'Lord', 'Lord', 'PROPN', 'NNP', 'pobj', 4, 'Xxxx', 'O', '',  True, False, [0, 35): 'She sold c shills by the Sith Lord.', 6, 8)


### PR DESCRIPTION
SpaCy shipped a new version of their library, with new language models that produce substantially different results even on simple text. This PR updates our regression tests to account for the latest SpaCy model changes.

I've also pinned the version of SpaCy in `dev_reqs.txt` to *exactly* 2.3.2 in the hopes that doing so will prevent this sort of thing from happening in the future.