### PR TITLE
Implement remaining hooks for TensorArray

### DIFF
--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -260,6 +260,12 @@ class TestTensor(unittest.TestCase):
         sum_some = df["s"][[True, False, True]].sum()
         npt.assert_array_equal(sum_some.to_numpy(), [6, 8])
 
+    def test_factorize(self):
+        x = np.array([[1, 2], [3, 4], [5, 6], [3, 4]])
+        s = TensorArray(x)
+        with self.assertRaises(NotImplementedError):
+            indices, values = s.factorize()
+
 
 class TensorArrayDataFrameTests(unittest.TestCase):
     def test_create(self):


### PR DESCRIPTION
Add remaining hooks for TensorArray. Calling `pandas.Series.factorize` still requires `_values_for_factorize` to be implemented.