### PR TITLE
Support for running notebooks on Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 # Text Extensions for Pandas
 
 [![Documentation Status](https://readthedocs.org/projects/text-extensions-for-pandas/badge/?version=latest)](https://text-extensions-for-pandas.readthedocs.io/en/latest/?badge=latest)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frreiss/tep-fred/branch-binder?urlpath=lab/tree/notebooks)
+
 
 Natural language processing support for Pandas dataframes.
 
@@ -61,10 +63,19 @@ of this repository to the front of `sys.path`.
 
 ## Documentation
 
-For examples of how to use the library, take a look at the notebooks in 
-[this directory](https://github.com/CODAIT/text-extensions-for-pandas/tree/master/notebooks).
+For examples of how to use the library, take a look at the **example notebooks** in 
+[this directory](https://github.com/CODAIT/text-extensions-for-pandas/tree/master/notebooks). You can try out these notebooks on [Binder](https://mybinder.org/) by navigating to [https://mybinder.org/v2/gh/frreiss/tep-fred/branch-binder?urlpath=lab/tree/notebooks](https://mybinder.org/v2/gh/frreiss/tep-fred/branch-binder?urlpath=lab/tree/notebooks)
 
-API documentation can be found at [https://readthedocs.org/projects/text-extensions-for-pandas/](https://readthedocs.org/projects/text-extensions-for-pandas/).
+To run the notebooks on your local machine, follow the following steps:
+
+1. Install [Anaconda](https://docs.anaconda.com/anaconda/install/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
+1. Check out a copy of this repository.
+1. Use the script `env.sh` to set up an Anaconda environment for running the code in this repository.
+1. Type `jupyter lab` from the root of your local source tree to start a [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) environment.
+1. Navigate to the `notebooks` directory and choose any of the notebooks there
+
+
+**API documentation** can be found at [https://readthedocs.org/projects/text-extensions-for-pandas/](https://readthedocs.org/projects/text-extensions-for-pandas/).
 
 
 ## Contents of this repository
@@ -83,11 +94,7 @@ API documentation can be found at [https://readthedocs.org/projects/text-extensi
   cover complex end-to-end NLP use cases (work in progress).
 
 
-## Instructions to run a demo notebook
-1. Check out a copy of this repository
-1. (optional) Use the script `env.sh` to set up an Anaconda environment for running the code in this repository.
-1. Type `jupyter lab` from the root of your local source tree to start a [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) environment.
-1. Navigate to the `notebooks` directory and choose any of the notebooks there
+## Instructions to run a demo notebook locally
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -74,12 +74,7 @@ To run the notebooks on your local machine, follow the following steps:
 1. Type `jupyter lab` from the root of your local source tree to start a [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) environment.
 1. Navigate to the `notebooks` directory and choose any of the notebooks there
 
-
-<<<<<<< HEAD
-**API documentation** can be found at [https://readthedocs.org/projects/text-extensions-for-pandas/](https://readthedocs.org/projects/text-extensions-for-pandas/).
-=======
 API documentation can be found at [https://text-extensions-for-pandas.readthedocs.io/en/latest/](https://text-extensions-for-pandas.readthedocs.io/en/latest/)
->>>>>>> 73bedd82ff67d33c9858511e551902e8d6da8061
 
 
 ## Contents of this repository
@@ -98,8 +93,6 @@ API documentation can be found at [https://text-extensions-for-pandas.readthedoc
 * **tutorials**: Detailed tutorials on using Text Extensions for Pandas to
   cover complex end-to-end NLP use cases (work in progress).
 
-
-## Instructions to run a demo notebook locally
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ To run the notebooks on your local machine, follow the following steps:
 * **env.sh**: Script to create a conda environment `pd` capable of running the notebooks and test cases in this project
 * **generate_docs.sh**: Script to build the [API documentation]((https://readthedocs.org/projects/text-extensions-for-pandas/)
 * **api_docs**: Configuration files for `generate_docs.sh`
+* **binder**: Configuration files for [running notebooks on Binder](https://mybinder.org/v2/gh/frreiss/tep-fred/branch-binder?urlpath=lab/tree/notebooks)
 * **config**: Configuration files for `env.sh`.
 * **docs**: Project web site
 * **notebooks**: example notebooks

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,8 @@
 # Post-build script for binder/repo2docker environment setup.
 
+# Log commands
+set -ex
+
 # Install additional packages beyond those in requirements.txt so that the
 # JupyterLab instance will be able to run all of the NLP library integrations.
 pip install -r config/dev_reqs.txt

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,8 @@
+# Post-build script for binder/repo2docker environment setup.
+
+# Install additional packages beyond those in requirements.txt so that the
+# JupyterLab instance will be able to run all of the NLP library integrations.
+pip install -r config/dev_reqs.txt
+pip install -r config/jupyter_reqs.txt
+
+


### PR DESCRIPTION
This PR adds the necessary configuration files and links to run our example notebooks on Binder. 

I've also added links to the README.md file. For now, the links point to the source branch for this PR. After these changes are merged, I'll update the links in the README.md in the master branch to point to master. 