### PR TITLE
Fixes for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-- "3.7"
+  - "3.7"
+  - "3.6"
 
 jobs:
   include:
@@ -10,25 +11,24 @@ jobs:
       env: PANDAS_VERSION=1.1.*
 
 install:
-#install conda
- - sudo apt-get update
- - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
- - bash miniconda.sh -b -p $HOME/miniconda
- - source "$HOME/miniconda/etc/profile.d/conda.sh"
- - hash -r
- - conda config --set always_yes yes --set changeps1 no
- - conda update -q conda
+  #install conda
+  - sudo apt-get update
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
 
- - conda info -a
+  - conda info -a
 
- - CONDA_HOME="${HOME}/miniconda" ./env.sh
+  - CONDA_HOME="${HOME}/miniconda" ./env.sh
 
 
 script:
-
- #activate python virtual environment
- - conda activate pd
- #check that doc generation is possible
- - ./generate_docs.sh
- #run unit tests 
- - pytest -v text_extensions_for_pandas
+  #activate python virtual environment
+  - conda activate pd
+  #check that doc generation is possible
+  - ./generate_docs.sh
+  #run unit tests
+  - pytest -v text_extensions_for_pandas

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
-python:
-  - "3.7"
-  - "3.6"
 
 jobs:
   include:
+    - python: "3.6"
     - name: "Pandas 1.0.x"
+      python: "3.7"
       env: PANDAS_VERSION=1.0.*
     - name: "Pandas 1.1.x"
+      python: "3.7"
       env: PANDAS_VERSION=1.1.*
 
 install:

--- a/text_extensions_for_pandas/__init__.py
+++ b/text_extensions_for_pandas/__init__.py
@@ -16,10 +16,10 @@
 ################################################################################
 # text_extensions_for_pandas
 #
-# NLP addons for Pandas dataframes.
+# NLP addons for Pandas DataFrames.
 #
 # To use:
-#   import text_extensions_for_pandas as pt
+#   import text_extensions_for_pandas as tp
 #
 
 
@@ -38,7 +38,8 @@ from text_extensions_for_pandas.array.tensor import (
 import text_extensions_for_pandas.array.accessor
 
 # Sub-modules
-import text_extensions_for_pandas.io as io
+from text_extensions_for_pandas import io
+from text_extensions_for_pandas import spanner
 
 # Sphinx autodoc needs this redundant listing of public symbols to list the contents
 # of this subpackage.

--- a/text_extensions_for_pandas/io/__init__.py
+++ b/text_extensions_for_pandas/io/__init__.py
@@ -21,10 +21,10 @@
 
 # Expose the public APIs that users should get from importing the top-level
 # library.
-import text_extensions_for_pandas.io.watson as watson
-import text_extensions_for_pandas.io.bert as bert
-import text_extensions_for_pandas.io.conll as conll
-import text_extensions_for_pandas.io.spacy as spacy
+from text_extensions_for_pandas.io import watson
+from text_extensions_for_pandas.io import bert
+from text_extensions_for_pandas.io import conll
+from text_extensions_for_pandas.io import spacy
 
 __all__ = ["watson", "bert", "conll", "spacy"]
 

--- a/text_extensions_for_pandas/io/test_bert.py
+++ b/text_extensions_for_pandas/io/test_bert.py
@@ -13,12 +13,14 @@
 #  limitations under the License.
 #
 
+import sys
 import unittest
 
 import pandas as pd
 import numpy as np
 import textwrap
 from typing import *
+import pytest
 
 # noinspection PyPackageRequirements
 from transformers import BertTokenizerFast, BertModel
@@ -32,6 +34,7 @@ from text_extensions_for_pandas.array.tensor import (
 )
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 6), reason="BertModel segfault")
 class TestTokenize(unittest.TestCase):
 
     @classmethod

--- a/text_extensions_for_pandas/io/test_bert.py
+++ b/text_extensions_for_pandas/io/test_bert.py
@@ -34,7 +34,7 @@ from text_extensions_for_pandas.array.tensor import (
 )
 
 
-@pytest.mark.skipif(sys.version_info[:2] <= (3, 6), reason="BertModel segfault")
+#@pytest.mark.skipif(sys.version_info[:2] <= (3, 6), reason="BertModel segfault")
 class TestTokenize(unittest.TestCase):
 
     @classmethod

--- a/text_extensions_for_pandas/io/test_bert.py
+++ b/text_extensions_for_pandas/io/test_bert.py
@@ -13,14 +13,12 @@
 #  limitations under the License.
 #
 
-import sys
 import unittest
 
 import pandas as pd
 import numpy as np
 import textwrap
 from typing import *
-import pytest
 
 # noinspection PyPackageRequirements
 from transformers import BertTokenizerFast, BertModel
@@ -34,7 +32,6 @@ from text_extensions_for_pandas.array.tensor import (
 )
 
 
-#@pytest.mark.skipif(sys.version_info[:2] <= (3, 6), reason="BertModel segfault")
 class TestTokenize(unittest.TestCase):
 
     @classmethod

--- a/text_extensions_for_pandas/io/watson/__init__.py
+++ b/text_extensions_for_pandas/io/watson/__init__.py
@@ -15,7 +15,7 @@
 
 # Expose the public APIs that users should get from importing the top-level
 # library.
-import text_extensions_for_pandas.io.watson.nlu as nlu
-import text_extensions_for_pandas.io.watson.tables as tables
+from text_extensions_for_pandas.io.watson import nlu
+from text_extensions_for_pandas.io.watson import tables
 
 __all__ = ["nlu", "tables"]

--- a/text_extensions_for_pandas/io/watson/tables.py
+++ b/text_extensions_for_pandas/io/watson/tables.py
@@ -33,8 +33,7 @@ can be used to authenticate and make requests to the service.
 import pandas as pd
 from typing import *
 import regex
-import text_extensions_for_pandas.io.watson.util as util
-
+from text_extensions_for_pandas.io.watson import util
 
 
 def _make_headers_df(headers_response):
@@ -474,6 +473,7 @@ def make_table(dfs_dict: Dict[str, pd.DataFrame], value_col="text", row_explode_
                                        sort_headers=sort_headers)
     table = substitute_text_names(table,dfs_dict,row_headers_by_id,col_headers_by_id)
     return table
+
 
 def make_exploded_df(dfs_dict: Dict[str, pd.DataFrame], drop_original: bool = True,
                      row_explode_by: str = None,


### PR DESCRIPTION
Fixed imports causing problems with Python 3.6. Import in the form of `import text_extensions_for_pandas.io.bert as bert` end up causing a circular reference due to later imports also referencing `io` which has not been initialized yet. Using the form `from text_extensions_for_pandas.io import bert` avoid this.