### PR TITLE
Fix TensorArray.isna() to handle types other than numeric

### DIFF
--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -198,7 +198,12 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         See docstring in `ExtensionArray` class in `pandas/core/arrays/base.py`
         for information about this method.
         """
-        return np.all(np.isnan(self._tensor), axis=-1)
+        if self._tensor.dtype.type is np.object_:
+            return self._tensor == None
+        elif self._tensor.dtype.type is np.str_:
+            return np.all(self._tensor == "", axis=-1)
+        else:
+            return np.all(np.isnan(self._tensor), axis=-1)
 
     def copy(self) -> "TensorArray":
         """

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -14,6 +14,7 @@
 #
 
 import os
+from distutils.version import LooseVersion
 import tempfile
 import textwrap
 import unittest
@@ -509,9 +510,9 @@ class TensorArrayDataFrameTests(unittest.TestCase):
         expected = np.array([[4, 5], [2, 3], [0, 1]])
         npt.assert_array_equal(df["tensor"].array, expected)
 
-    def test_large_display(self):
+    def test_large_display_numeric(self):
 
-        # Test numeric
+        # Test integer, uses IntArrayFormatter
         df = pd.DataFrame({"foo": TensorArray(np.array([[1, 2]] * 100))})
         self.assertEqual(
             repr(df),
@@ -534,7 +535,34 @@ class TensorArrayDataFrameTests(unittest.TestCase):
             )
         )
 
-        # Test string
+        # Test float, uses IntArrayFormatter
+        df = pd.DataFrame({"foo": TensorArray(np.array([[1.1, 2.2]] * 100))})
+        self.assertEqual(
+            repr(df),
+            textwrap.dedent(
+                """\
+                         foo
+                0  [1.1 2.2]
+                1  [1.1 2.2]
+                2  [1.1 2.2]
+                3  [1.1 2.2]
+                4  [1.1 2.2]
+                ..       ...
+                95 [1.1 2.2]
+                96 [1.1 2.2]
+                97 [1.1 2.2]
+                98 [1.1 2.2]
+                99 [1.1 2.2]
+                
+                [100 rows x 1 columns]"""
+            )
+        )
+
+    @pytest.mark.skipif(LooseVersion(pd.__version__) < LooseVersion("1.1.0"),
+                        reason="Display of TensorArray with non-numeric dtype not supported")
+    def test_large_display_string(self):
+
+        # Uses the GenericArrayFormatter, doesn't work for Pandas 1.0.x but fixed in later versions
         df = pd.DataFrame({"foo": TensorArray(np.array([["Hello", "world"]] * 100))})
         self.assertEqual(
             repr(df),

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -195,7 +195,7 @@ class TestTensor(unittest.TestCase):
 
         # Test object
         d = {"a": 1}
-        x = np.array([[d, d], None, [d, None], [d, d]])
+        x = np.array([[d, d], None, [d, None], [d, d]], dtype=object)
         s = TensorArray(x)
         result = s.isna()
         npt.assert_equal(result, expected)

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -184,6 +184,28 @@ class TestTensor(unittest.TestCase):
         a[1] = np.array([42, 42])
         npt.assert_equal(a[1], [42, 42])
 
+    def test_isna(self):
+        expected = np.array([False, True, False, False])
+
+        # Test numeric
+        x = np.array([[1, 2], [np.nan, np.nan], [3, np.nan], [5, 6]])
+        s = TensorArray(x)
+        result = s.isna()
+        npt.assert_equal(result, expected)
+
+        # Test object
+        d = {"a": 1}
+        x = np.array([[d, d], None, [d, None], [d, d]])
+        s = TensorArray(x)
+        result = s.isna()
+        npt.assert_equal(result, expected)
+
+        # Test str
+        x = np.array([["foo", "foo"], ["", ""], ["bar", ""], ["baz", "baz"]])
+        s = TensorArray(x)
+        result = s.isna()
+        npt.assert_equal(result, expected)
+
     def test_repr(self):
         x = np.array([[1, 2], [3, 4], [5, 6]])
         expected = textwrap.dedent(
@@ -486,6 +508,54 @@ class TensorArrayDataFrameTests(unittest.TestCase):
         self.assertEqual(df["tensor"].array.to_numpy().dtype, arr.to_numpy().dtype)
         expected = np.array([[4, 5], [2, 3], [0, 1]])
         npt.assert_array_equal(df["tensor"].array, expected)
+
+    def test_large_display(self):
+
+        # Test numeric
+        df = pd.DataFrame({"foo": TensorArray(np.array([[1, 2]] * 100))})
+        self.assertEqual(
+            repr(df),
+            textwrap.dedent(
+                """\
+                     foo
+                0  [1 2]
+                1  [1 2]
+                2  [1 2]
+                3  [1 2]
+                4  [1 2]
+                ..   ...
+                95 [1 2]
+                96 [1 2]
+                97 [1 2]
+                98 [1 2]
+                99 [1 2]
+                
+                [100 rows x 1 columns]"""
+            )
+        )
+
+        # Test string
+        df = pd.DataFrame({"foo": TensorArray(np.array([["Hello", "world"]] * 100))})
+        self.assertEqual(
+            repr(df),
+            textwrap.dedent(
+                """\
+                                  foo
+                0   ['Hello' 'world']
+                1   ['Hello' 'world']
+                2   ['Hello' 'world']
+                3   ['Hello' 'world']
+                4   ['Hello' 'world']
+                ..                ...
+                95  ['Hello' 'world']
+                96  ['Hello' 'world']
+                97  ['Hello' 'world']
+                98  ['Hello' 'world']
+                99  ['Hello' 'world']
+                
+                [100 rows x 1 columns]"""
+            )
+        )
 
 
 class TensorArrayIOTests(unittest.TestCase):


### PR DESCRIPTION
TensorArray.isna() used numpy functions only for numeric types. This change adds checks for numpy objects and strings.

Fixes #132 