### PR TITLE
Fix TensorArray aggregations that produce ndarray of objects

### DIFF
--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -140,7 +140,11 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         :param values: A `numpy.ndarray` or sequence of `numpy.ndarray`s of equal shape.
         """
         if isinstance(values, np.ndarray):
-            self._tensor = values
+            if values.dtype.type is np.object_ and len(values) > 0 and \
+                    isinstance(values[0], TensorElement):
+                self._tensor = np.array([np.asarray(v) for v in values])
+            else:
+                self._tensor = values
         elif isinstance(values, Sequence):
             if len(values) == 0:
                 self._tensor = np.array([])
@@ -362,11 +366,11 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         for information about this method.
         """
         if name == "sum":
-            return TensorArray(np.sum(self._tensor, axis=0))
+            return TensorElement(np.sum(self._tensor, axis=0))
         elif name == "all":
-            return TensorArray(np.all(self._tensor, axis=0))
+            return TensorElement(np.all(self._tensor, axis=0))
         elif name == "any":
-            return TensorArray(np.any(self._tensor, axis=0))
+            return TensorElement(np.any(self._tensor, axis=0))
         else:
             raise NotImplementedError(f"'{name}' aggregate not implemented.")
 

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -423,15 +423,22 @@ class TensorArrayDataFrameTests(unittest.TestCase):
         values = np.array([[1, 1]] * len(keys))
         df = pd.DataFrame({"key": keys, "value": TensorArray(values)})
         result_df = df.groupby("key").aggregate({"value": "sum"})
+
+        # Check array gets unwrapped from TensorElements
+        arr = result_df["value"].array
+        self.assertEqual(arr.to_numpy().dtype, values.dtype)
+        npt.assert_array_equal(arr.to_numpy(), [[2, 2], [1, 1], [3, 3]])
+
+        # Check the resulting DataFrame
         self.assertEqual(
             repr(result_df),
             textwrap.dedent(
                 """\
-                     value
-                key       
-                a    [2 2]
-                b    [1 1]
-                c    [3 3]"""
+                    value
+                key      
+                a   [2 2]
+                b   [1 1]
+                c   [3 3]"""
             ),
         )
 
@@ -439,17 +446,25 @@ class TensorArrayDataFrameTests(unittest.TestCase):
         values2 = np.array([[[1, 1], [1, 1]]] * len(keys))
         df2 = pd.DataFrame({"key": keys, "value": TensorArray(values2)})
         result2_df = df2.groupby("key").aggregate({"value": "sum"})
+
+        # Check array gets unwrapped from TensorElements
+        arr2 = result2_df["value"].array
+        self.assertEqual(arr2.to_numpy().dtype, values.dtype)
+        npt.assert_array_equal(arr2.to_numpy(),
+                               [[[2, 2], [2, 2]], [[1, 1], [1, 1]], [[3, 3], [3, 3]]])
+
+        # Check the resulting DataFrame
         self.assertEqual(
             repr(result2_df),
             textwrap.dedent(
                 """\
-                              value
-                key                
-                a    [[2 2]
+                             value
+                key               
+                a   [[2 2]
                  [2 2]]
-                b    [[1 1]
+                b   [[1 1]
                  [1 1]]
-                c    [[3 3]
+                c   [[3 3]
                  [3 3]]"""
             ),
         )


### PR DESCRIPTION
`TensorArray` aggregations were producing a ndarray of `TensorArray`s for each group. This changes aggs to produce a `TensorElement` as a scalar, then allow construction of a new `TensorArray` using an ndarray of the resulting `TensorElement` objects.

Fixes #124 