### PR TITLE
Add code to convert NLU entity mentions information to a DataFrame

### DIFF
--- a/notebooks/Analyze_Text.ipynb
+++ b/notebooks/Analyze_Text.ipynb
@@ -143,7 +143,7 @@
     {
      "data": {
       "text/plain": [
-       "<ibm_watson.natural_language_understanding_v1.NaturalLanguageUnderstandingV1 at 0x7ffa4f50ed10>"
+       "<ibm_watson.natural_language_understanding_v1.NaturalLanguageUnderstandingV1 at 0x7fac2fa33cd0>"
       ]
      },
      "execution_count": 3,
@@ -229,7 +229,7 @@
     "    #url=\"https://raw.githubusercontent.com/CODAIT/text-extensions-for-pandas/master/resources/holy_grail_short.txt\",\n",
     "    return_analyzed_text=True,\n",
     "    features=nlu.Features(\n",
-    "        entities=nlu.EntitiesOptions(sentiment=True),\n",
+    "        entities=nlu.EntitiesOptions(sentiment=True, mentions=True),\n",
     "        keywords=nlu.KeywordsOptions(sentiment=True, emotion=True),\n",
     "        relations=nlu.RelationsOptions(),\n",
     "        semantic_roles=nlu.SemanticRolesOptions(),\n",
@@ -340,7 +340,7 @@
        "   'part_of_speech': 'ADP',\n",
        "   'location': [0, 2],\n",
        "   'lemma': 'in'},\n",
-       "  {'text': 'AD', 'part_of_speech': 'PROPN', 'location': [3, 5], 'lemma': 'ad'},\n",
+       "  {'text': 'AD', 'part_of_speech': 'NOUN', 'location': [3, 5], 'lemma': 'ad'},\n",
        "  {'text': '932', 'part_of_speech': 'NUM', 'location': [6, 9]},\n",
        "  {'text': ',', 'part_of_speech': 'PUNCT', 'location': [9, 10]},\n",
        "  {'text': 'King',\n",
@@ -412,11 +412,11 @@
        "   'location': [113, 116],\n",
        "   'lemma': 'the'},\n",
        "  {'text': 'Round',\n",
-       "   'part_of_speech': 'ADJ',\n",
+       "   'part_of_speech': 'PROPN',\n",
        "   'location': [117, 122],\n",
        "   'lemma': 'round'},\n",
        "  {'text': 'Table',\n",
-       "   'part_of_speech': 'NOUN',\n",
+       "   'part_of_speech': 'PROPN',\n",
        "   'location': [123, 128],\n",
        "   'lemma': 'table'},\n",
        "  {'text': '.', 'part_of_speech': 'PUNCT', 'location': [128, 129]},\n",
@@ -465,7 +465,7 @@
        "   'location': [193, 196],\n",
        "   'lemma': 'the'},\n",
        "  {'text': 'Brave',\n",
-       "   'part_of_speech': 'ADJ',\n",
+       "   'part_of_speech': 'PROPN',\n",
        "   'location': [197, 202],\n",
        "   'lemma': 'brave'},\n",
        "  {'text': ',', 'part_of_speech': 'PUNCT', 'location': [202, 203]},\n",
@@ -537,7 +537,7 @@
        "   'location': [284, 287],\n",
        "   'lemma': 'not'},\n",
        "  {'text': '-', 'part_of_speech': 'PUNCT', 'location': [287, 288]},\n",
-       "  {'text': 'Appearing', 'part_of_speech': 'NOUN', 'location': [288, 297]},\n",
+       "  {'text': 'Appearing', 'part_of_speech': 'PROPN', 'location': [288, 297]},\n",
        "  {'text': '-', 'part_of_speech': 'PUNCT', 'location': [297, 298]},\n",
        "  {'text': 'in',\n",
        "   'part_of_speech': 'ADP',\n",
@@ -555,7 +555,7 @@
        "   'lemma': 'film'},\n",
        "  {'text': ',', 'part_of_speech': 'PUNCT', 'location': [310, 311]},\n",
        "  {'text': 'along',\n",
-       "   'part_of_speech': 'ADV',\n",
+       "   'part_of_speech': 'ADP',\n",
        "   'location': [312, 317],\n",
        "   'lemma': 'along'},\n",
        "  {'text': 'with',\n",
@@ -930,7 +930,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['syntax', 'entities', 'keywords', 'relations', 'semantic_roles'])"
+       "dict_keys(['syntax', 'entities', 'entity_mentions', 'keywords', 'relations', 'semantic_roles'])"
       ]
      },
      "execution_count": 10,
@@ -994,7 +994,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>[3, 5): 'AD'</td>\n",
-       "      <td>PROPN</td>\n",
+       "      <td>NOUN</td>\n",
        "      <td>ad</td>\n",
        "      <td>[0, 129): 'In AD 932, King Arthur and his squi...</td>\n",
        "    </tr>\n",
@@ -1069,7 +1069,7 @@
       "text/plain": [
        "                      span part_of_speech lemma  \\\n",
        "0             [0, 2): 'In'            ADP    in   \n",
-       "1             [3, 5): 'AD'          PROPN    ad   \n",
+       "1             [3, 5): 'AD'           NOUN    ad   \n",
        "2            [6, 9): '932'            NUM  None   \n",
        "3             [9, 10): ','          PUNCT  None   \n",
        "4         [11, 15): 'King'          PROPN  king   \n",
@@ -1279,7 +1279,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>[3, 5): 'AD'</td>\n",
-       "      <td>PROPN</td>\n",
+       "      <td>NOUN</td>\n",
        "      <td>ad</td>\n",
        "      <td>[0, 129): 'In AD 932, King Arthur and his squi...</td>\n",
        "    </tr>\n",
@@ -1297,7 +1297,7 @@
       "text/plain": [
        "            span part_of_speech lemma  \\\n",
        "0   [0, 2): 'In'            ADP    in   \n",
-       "1   [3, 5): 'AD'          PROPN    ad   \n",
+       "1   [3, 5): 'AD'           NOUN    ad   \n",
        "2  [6, 9): '932'            NUM  None   \n",
        "\n",
        "                                            sentence  \n",
@@ -1650,7 +1650,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>[3, 5): 'AD'</td>\n",
-       "      <td>PROPN</td>\n",
+       "      <td>NOUN</td>\n",
        "      <td>ad</td>\n",
        "      <td>[0, 129): 'In AD 932, King Arthur and his squi...</td>\n",
        "    </tr>\n",
@@ -1668,7 +1668,7 @@
       "text/plain": [
        "            span part_of_speech lemma  \\\n",
        "0   [0, 2): 'In'            ADP    in   \n",
-       "1   [3, 5): 'AD'          PROPN    ad   \n",
+       "1   [3, 5): 'AD'           NOUN    ad   \n",
        "2  [6, 9): '932'            NUM  None   \n",
        "\n",
        "                                            sentence  \n",
@@ -2275,7 +2275,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['syntax', 'entities', 'keywords', 'relations', 'semantic_roles'])"
+       "dict_keys(['syntax', 'entities', 'entity_mentions', 'keywords', 'relations', 'semantic_roles'])"
       ]
      },
      "execution_count": 28,
@@ -2293,6 +2293,14 @@
    "source": [
     "The \"syntax\" element of `dfs` contains the syntax analysis DataFrame that we showed earlier.\n",
     "Let's take a look at the other elements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The \"entities\" element of `dfs` contains the named entities that Watson Natural Language \n",
+    "Understanding found in the document."
    ]
   },
   {
@@ -2436,8 +2444,289 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The \"entity_mentions\" element of `dfs` contains the locations of individual mentions of\n",
+    "entities from the \"entities\" DataFrame. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>type</th>\n",
+       "      <th>text</th>\n",
+       "      <th>span</th>\n",
+       "      <th>confidence</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Sir Bedevere</td>\n",
+       "      <td>[157, 169): 'Sir Bedevere'</td>\n",
+       "      <td>0.975353</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Sir Not</td>\n",
+       "      <td>[280, 287): 'Sir Not'</td>\n",
+       "      <td>0.655069</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>King Arthur</td>\n",
+       "      <td>[11, 22): 'King Arthur'</td>\n",
+       "      <td>0.985337</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Patsy</td>\n",
+       "      <td>[39, 44): 'Patsy'</td>\n",
+       "      <td>0.489775</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Sir Lancelot</td>\n",
+       "      <td>[180, 192): 'Sir Lancelot'</td>\n",
+       "      <td>0.962657</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     type          text                        span  confidence\n",
+       "0  Person  Sir Bedevere  [157, 169): 'Sir Bedevere'    0.975353\n",
+       "1  Person       Sir Not       [280, 287): 'Sir Not'    0.655069\n",
+       "2  Person   King Arthur     [11, 22): 'King Arthur'    0.985337\n",
+       "3  Person         Patsy           [39, 44): 'Patsy'    0.489775\n",
+       "4  Person  Sir Lancelot  [180, 192): 'Sir Lancelot'    0.962657"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dfs[\"entity_mentions\"].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the DataFrame under \"entitiy_mentions\" may contain multiple mentions of the same\n",
+    "name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>type</th>\n",
+       "      <th>text</th>\n",
+       "      <th>span</th>\n",
+       "      <th>confidence</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Arthur</td>\n",
+       "      <td>[362, 368): 'Arthur'</td>\n",
+       "      <td>0.998380</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Arthur</td>\n",
+       "      <td>[587, 593): 'Arthur'</td>\n",
+       "      <td>0.990608</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      type    text                  span  confidence\n",
+       "10  Person  Arthur  [362, 368): 'Arthur'    0.998380\n",
+       "11  Person  Arthur  [587, 593): 'Arthur'    0.990608"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "arthur_mentions = dfs[\"entity_mentions\"][dfs[\"entity_mentions\"][\"text\"] == \"Arthur\"]\n",
+    "arthur_mentions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The \"type\" and \"text\" columns of the \"entity_mentions\" DataFrame refer back to the \n",
+    "\"entities\" DataFrame columns of the same names.\n",
+    "You can combine the global and local information about entities into a single DataFrame\n",
+    "using Pandas' `DataFrame.merge()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>type</th>\n",
+       "      <th>text</th>\n",
+       "      <th>span</th>\n",
+       "      <th>confidence_mention</th>\n",
+       "      <th>sentiment.label</th>\n",
+       "      <th>sentiment.score</th>\n",
+       "      <th>relevance</th>\n",
+       "      <th>count</th>\n",
+       "      <th>confidence_entity</th>\n",
+       "      <th>disambiguation.subtype</th>\n",
+       "      <th>disambiguation.name</th>\n",
+       "      <th>disambiguation.dbpedia_resource</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Arthur</td>\n",
+       "      <td>[362, 368): 'Arthur'</td>\n",
+       "      <td>0.998380</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>0.721918</td>\n",
+       "      <td>0.311653</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.999985</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Person</td>\n",
+       "      <td>Arthur</td>\n",
+       "      <td>[587, 593): 'Arthur'</td>\n",
+       "      <td>0.990608</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>0.721918</td>\n",
+       "      <td>0.311653</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.999985</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     type    text                  span  confidence_mention sentiment.label  \\\n",
+       "0  Person  Arthur  [362, 368): 'Arthur'            0.998380        positive   \n",
+       "1  Person  Arthur  [587, 593): 'Arthur'            0.990608        positive   \n",
+       "\n",
+       "   sentiment.score  relevance  count  confidence_entity  \\\n",
+       "0         0.721918   0.311653      2           0.999985   \n",
+       "1         0.721918   0.311653      2           0.999985   \n",
+       "\n",
+       "  disambiguation.subtype disambiguation.name disambiguation.dbpedia_resource  \n",
+       "0                   None                None                            None  \n",
+       "1                   None                None                            None  "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "arthur_mentions.merge(dfs[\"entities\"], on=[\"type\", \"text\"], suffixes=[\"_mention\", \"_entity\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -2505,7 +2794,7 @@
        "      <td>image of W. G. Grace</td>\n",
        "      <td>positive</td>\n",
        "      <td>0.721918</td>\n",
-       "      <td>0.757585</td>\n",
+       "      <td>0.758922</td>\n",
        "      <td>0.047242</td>\n",
        "      <td>0.614332</td>\n",
        "      <td>0.159497</td>\n",
@@ -2518,7 +2807,7 @@
        "      <td>Sir Galahad</td>\n",
        "      <td>positive</td>\n",
        "      <td>0.835873</td>\n",
-       "      <td>0.634168</td>\n",
+       "      <td>0.635859</td>\n",
        "      <td>0.046902</td>\n",
        "      <td>0.810654</td>\n",
        "      <td>0.016340</td>\n",
@@ -2547,8 +2836,8 @@
        "                   text sentiment.label  sentiment.score  relevance  \\\n",
        "0           King Arthur         neutral         0.000000   0.864073   \n",
        "1          Sir Lancelot        positive         0.835873   0.820529   \n",
-       "2  image of W. G. Grace        positive         0.721918   0.757585   \n",
-       "3           Sir Galahad        positive         0.835873   0.634168   \n",
+       "2  image of W. G. Grace        positive         0.721918   0.758922   \n",
+       "3           Sir Galahad        positive         0.835873   0.635859   \n",
        "4        musical number         neutral         0.000000   0.628727   \n",
        "\n",
        "   emotion.sadness  emotion.joy  emotion.fear  emotion.disgust  emotion.anger  \\\n",
@@ -2566,7 +2855,7 @@
        "4      1  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2577,7 +2866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -2707,7 +2996,7 @@
        "4                   Camelot  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2718,7 +3007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -2829,7 +3118,7 @@
        "4       to go             to go  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/test_data/io/test_watson/mentions_response.txt
+++ b/test_data/io/test_watson/mentions_response.txt
@@ -1,0 +1,25 @@
+{
+    "usage": {"text_units": 1, "text_characters": 190, "features": 1},
+    "language": "en",
+    "entities": [
+        {
+            "type": "Person", "text": "Steven Wright",
+            "sentiment": {"score": -0.866897, "label": "negative"},
+            "relevance": 0.978348, "mentions": [
+                {"text": "Steven Wright", "location": [64, 77], "confidence": 0.998251},
+                {"text": "Steven Wright", "location": [177, 190], "confidence": 0.998251}
+            ],
+            "count": 2, "confidence": 0.999997
+        },
+        {
+            "type": "Location",
+            "text": "Alaska",
+            "sentiment": {"score": -0.940095, "label": "negative"},
+            "relevance": 0.277941,
+            "mentions": [
+                {"text": "Alaska", "location": [138, 144], "confidence": 0.999498}
+            ],
+            "count": 1, "confidence": 0.999498}
+    ],
+    "analyzed_text": "If Barbie is so popular, why do you have to buy her friends?\n-- Steven Wright\nThe Bermuda Triangle got tired of warm weather.\nIt moved to Alaska. Now Santa Claus is missing.\n-- Steven Wright"
+}

--- a/text_extensions_for_pandas/io/watson/util.py
+++ b/text_extensions_for_pandas/io/watson/util.py
@@ -33,6 +33,8 @@ def schema_to_names(schema):
 
 
 def apply_schema(df, schema, std_schema_on):
+    # TODO: Apply the dtype information in schema, not just the names
+    # TODO: Document what this mysterious "std_schema_on" argument does.
     columns = [n for n in schema_to_names(schema) if std_schema_on or n in df.columns]
     return df.reindex(columns=columns)
 
@@ -89,6 +91,15 @@ def build_original_text(text_col, begins):
 
 
 def make_char_span(location_col, text_col, original_text):
+    """
+    Convert a column of begin, end pairs to a SpanArray.
+
+    :param location_col: Arrow array containing (begin, end) tuples of character offset
+    :param text_col: Arrow array of strings that should match the target texts of the
+      spans in location_col. Used for reconstructing target text when it is not provided.
+    :param original_text: Target text for the spans. Optional. If not provided, this
+     function will reconstruct target text from the contents of `text_col`.
+    """
 
     # Replace location columns with char and token spans
     if not (pa.types.is_list(location_col.type) and pa.types.is_primitive(location_col.type.value_type)):


### PR DESCRIPTION
This PR implements the feature described in #54.

I've added code to `nlu.py` to unroll the nested information that NLU returns about entity mentions into a DataFrame with one row per entity mention. After my modifications, the `parse_response()` method returns a dictionary with an additional key "entity_mentions" that points to the new DataFrame. If the user didn't tell NLU to extract entity mentions, this DataFrame will be empty but will still be present.

I added some new tests to cover the new functionality. I also updated the main NLU-related notebook with some Markdown to explain what's stored under the "entity_mentions" key in the return value of `parse_response()`.