### PR TITLE
Handle corner cases involving empty inputs to overlaps/contains join

### DIFF
--- a/text_extensions_for_pandas/array/span.py
+++ b/text_extensions_for_pandas/array/span.py
@@ -291,9 +291,8 @@ class SpanArray(pd.api.extensions.ExtensionArray, SpanOpMixin):
         if not isinstance(ends, (pd.Series, np.ndarray, list)):
             raise TypeError(f"ends is of unsupported type {type(ends)}. "
                             f"Supported types are Series, ndarray and List[int].")
-        begins = (np.array(begins, dtype=int) if not isinstance(begins, np.ndarray)
-                  else begins)
-        ends = np.array(ends, dtype=int) if not isinstance(ends, np.ndarray) else ends
+        begins = np.array(begins, dtype=int)
+        ends = np.array(ends, dtype=int)
 
         if not np.issubdtype(begins.dtype, np.integer):
             raise TypeError(f"Begins array is of dtype {begins.dtype}, "

--- a/text_extensions_for_pandas/array/span.py
+++ b/text_extensions_for_pandas/array/span.py
@@ -32,6 +32,7 @@ from memoized_property import memoized_property
 
 # Internal imports
 import text_extensions_for_pandas.jupyter as jupyter
+from text_extensions_for_pandas.util import to_int_array
 
 
 def _check_same_text(o1, o2):
@@ -291,8 +292,8 @@ class SpanArray(pd.api.extensions.ExtensionArray, SpanOpMixin):
         if not isinstance(ends, (pd.Series, np.ndarray, list)):
             raise TypeError(f"ends is of unsupported type {type(ends)}. "
                             f"Supported types are Series, ndarray and List[int].")
-        begins = np.array(begins, dtype=int)
-        ends = np.array(ends, dtype=int)
+        begins = to_int_array(begins)
+        ends = to_int_array(ends)
 
         if not np.issubdtype(begins.dtype, np.integer):
             raise TypeError(f"Begins array is of dtype {begins.dtype}, "

--- a/text_extensions_for_pandas/array/span.py
+++ b/text_extensions_for_pandas/array/span.py
@@ -291,8 +291,9 @@ class SpanArray(pd.api.extensions.ExtensionArray, SpanOpMixin):
         if not isinstance(ends, (pd.Series, np.ndarray, list)):
             raise TypeError(f"ends is of unsupported type {type(ends)}. "
                             f"Supported types are Series, ndarray and List[int].")
-        begins = np.array(begins) if not isinstance(begins, np.ndarray) else begins
-        ends = np.array(ends) if not isinstance(ends, np.ndarray) else ends
+        begins = (np.array(begins, dtype=int) if not isinstance(begins, np.ndarray)
+                  else begins)
+        ends = np.array(ends, dtype=int) if not isinstance(ends, np.ndarray) else ends
 
         if not np.issubdtype(begins.dtype, np.integer):
             raise TypeError(f"Begins array is of dtype {begins.dtype}, "

--- a/text_extensions_for_pandas/array/token_span.py
+++ b/text_extensions_for_pandas/array/token_span.py
@@ -295,14 +295,8 @@ class TokenSpanArray(SpanArray, TokenSpanOpMixin):
 
         super().__init__(tokens.target_text, tokens.begin, tokens.end)
 
-        begin_tokens = (
-            np.array(begin_tokens, dtype=int) if not isinstance(begin_tokens, np.ndarray)
-            else begin_tokens
-        )
-        end_tokens = (
-            np.array(end_tokens, dtype=int) if not isinstance(end_tokens, np.ndarray)
-            else end_tokens
-        )
+        begin_tokens = np.array(begin_tokens, dtype=int)
+        end_tokens = np.array(end_tokens, dtype=int)
 
         self._begin_tokens = begin_tokens  # Type: np.ndarray
         self._end_tokens = end_tokens  # Type: np.ndarray

--- a/text_extensions_for_pandas/array/token_span.py
+++ b/text_extensions_for_pandas/array/token_span.py
@@ -37,6 +37,7 @@ from text_extensions_for_pandas.array.span import (
     SpanDtype,
     SpanOpMixin
 )
+from text_extensions_for_pandas.util import to_int_array
 
 
 def _check_same_tokens(array1, array2):
@@ -295,8 +296,8 @@ class TokenSpanArray(SpanArray, TokenSpanOpMixin):
 
         super().__init__(tokens.target_text, tokens.begin, tokens.end)
 
-        begin_tokens = np.array(begin_tokens, dtype=int)
-        end_tokens = np.array(end_tokens, dtype=int)
+        begin_tokens = to_int_array(begin_tokens)
+        end_tokens = to_int_array(end_tokens)
 
         self._begin_tokens = begin_tokens  # Type: np.ndarray
         self._end_tokens = end_tokens  # Type: np.ndarray

--- a/text_extensions_for_pandas/array/token_span.py
+++ b/text_extensions_for_pandas/array/token_span.py
@@ -296,11 +296,11 @@ class TokenSpanArray(SpanArray, TokenSpanOpMixin):
         super().__init__(tokens.target_text, tokens.begin, tokens.end)
 
         begin_tokens = (
-            np.array(begin_tokens) if not isinstance(begin_tokens, np.ndarray)
+            np.array(begin_tokens, dtype=int) if not isinstance(begin_tokens, np.ndarray)
             else begin_tokens
         )
         end_tokens = (
-            np.array(end_tokens) if not isinstance(end_tokens, np.ndarray)
+            np.array(end_tokens, dtype=int) if not isinstance(end_tokens, np.ndarray)
             else end_tokens
         )
 

--- a/text_extensions_for_pandas/spanner/test_join.py
+++ b/text_extensions_for_pandas/spanner/test_join.py
@@ -238,11 +238,11 @@ class JoinTest(TestBase):
         self.assertIsInstance(result1["first"].dtype, SpanDtype)
         self.assertIsInstance(result1["second"].dtype, TokenSpanDtype)
 
-        result2 = overlap_join(self._make_empty_series_span_array(),
-                               self._make_join_arg())
-        self.assertEqual(len(result1.index), 0)
-        self.assertIsInstance(result1["first"].dtype, SpanDtype)
-        self.assertIsInstance(result1["second"].dtype, TokenSpanDtype)
+        result2 = overlap_join(self._make_join_arg(),
+                               self._make_empty_series_span_array())
+        self.assertEqual(len(result2.index), 0)
+        self.assertIsInstance(result2["first"].dtype, TokenSpanDtype)
+        self.assertIsInstance(result2["second"].dtype, SpanDtype)
 
         result3 = overlap_join(self._make_empty_series_span_array(),
                                self._make_empty_series_span_array())

--- a/text_extensions_for_pandas/spanner/test_join.py
+++ b/text_extensions_for_pandas/spanner/test_join.py
@@ -19,10 +19,12 @@ import pandas as pd
 import regex
 from spacy.lang.en import English
 
+from text_extensions_for_pandas import SpanArray, SpanDtype
 from text_extensions_for_pandas.spanner.extract import extract_regex_tok
 from text_extensions_for_pandas.io.spacy import make_tokens
 from text_extensions_for_pandas.util import TestBase
-from text_extensions_for_pandas.array.token_span import (TokenSpan, TokenSpanArray)
+from text_extensions_for_pandas.array.token_span import (TokenSpan, TokenSpanArray,
+                                                         TokenSpanDtype)
 from text_extensions_for_pandas.spanner.join import (
     adjacent_join,
     contain_join,
@@ -42,7 +44,7 @@ searching for men to join the Knights of the Round Table. Along the way, he
 recruits Sir Bedevere the Wise, Sir Lancelot the Brave, Sir Galahad the Pure...
 """
 _TOKENS_SERIES = make_tokens(_TEXT, _tokenizer)
-_TOKENS_ARRAY = _TOKENS_SERIES.values  # Type: SpanArray
+_TOKENS_ARRAY = _TOKENS_SERIES.array  # type: SpanArray
 _TOKEN_SPANS_ARRAY = TokenSpanArray.from_char_offsets(_TOKENS_ARRAY)
 _CAPS_WORD = extract_regex_tok(_TOKENS_ARRAY, regex.compile("[A-Z][a-z]*"))
 _CAPS_WORDS = extract_regex_tok(
@@ -117,10 +119,11 @@ class JoinTest(TestBase):
             ),
         )
 
-
-
-    def test_overlaps_join(self):
-        join_arg = pd.Series(
+    def _make_join_arg(self) -> pd.Series:
+        """
+        Shared example join argument used by most of the test cases that follow.
+        """
+        return pd.Series(
             TokenSpanArray._from_sequence(
                 [
                     TokenSpan(_TOKENS_ARRAY, 23, 28),  # Knights of the Round Table
@@ -132,9 +135,36 @@ class JoinTest(TestBase):
             )
         )
 
-        result1 = overlap_join(join_arg, _CAPS_WORD["match"])
+    def _make_join_arg_span_array(self) -> pd.Series:
+        """
+        Version of the result of _make_join_arg() as a SpanArray instead of a
+        TokenSpanArray.
+        """
+        # noinspection PyTypeChecker
+        token_span_array = self._make_join_arg().array  # type: TokenSpanArray
+        span_array = SpanArray(_TEXT, token_span_array.begin, token_span_array.end)
+        return pd.Series(span_array)
+
+    @staticmethod
+    def _make_empty_series() -> pd.Series:
+        """
+        Zero-length TokenSpanArray wrapped in a series. Note that this array has
+        zero spans but *does* contain token and text information.
+        """
+        return pd.Series(
+            TokenSpanArray(_TOKENS_ARRAY, [], [])
+        )
+
+    @staticmethod
+    def _make_empty_series_span_array() -> pd.Series:
+        return pd.Series(SpanArray(_TEXT, [], []))
+
+    def test_overlaps_join_left_spans_longer(self):
+        result = overlap_join(self._make_join_arg(), _CAPS_WORD["match"])
         self.assertEqual(
-            str(result1),
+            str(result),
+            # Note that offsets are in *tokens*, because this test class enables the
+            # TokenSpan.USE_TOKEN_OFFSETS_IN_REPR flag.
             textwrap.dedent(
                 """\
                                                 first                second
@@ -148,9 +178,10 @@ class JoinTest(TestBase):
             ),
         )
 
-        result2 = overlap_join(_CAPS_WORD["match"], join_arg)
+    def test_overlaps_join_right_spans_longer(self):
+        result = overlap_join(_CAPS_WORD["match"], self._make_join_arg())
         self.assertEqual(
-            str(result2),
+            str(result),
             textwrap.dedent(
                 """\
                               first                                  second
@@ -163,6 +194,61 @@ class JoinTest(TestBase):
             6     [44, 45): 'Brave'          [42, 45): 'Lancelot the Brave'"""
             ),
         )
+
+    def test_overlaps_join_left_char_spans(self):
+        result = overlap_join(self._make_join_arg_span_array(), _CAPS_WORD["match"])
+        self.assertEqual(
+            str(result),
+            # Note the span offsets instead of token offsets in "first"
+            textwrap.dedent(
+                """\
+                                                      first                second
+                0  [104, 130): 'Knights of the Round Table'   [23, 24): 'Knights'
+                1  [104, 130): 'Knights of the Round Table'     [26, 27): 'Round'
+                2  [104, 130): 'Knights of the Round Table'     [27, 28): 'Table'
+                3                              [1, 3): 'In'          [1, 2): 'In'
+                4                              [1, 3): 'In'          [1, 2): 'In'
+                5          [187, 205): 'Lancelot the Brave'  [42, 43): 'Lancelot'
+                6          [187, 205): 'Lancelot the Brave'     [44, 45): 'Brave'"""
+            ),
+        )
+
+    def test_overlaps_join_empty_input(self):
+        # Empty input should produce empty result with valid token info.
+        result1 = overlap_join(self._make_empty_series(), self._make_join_arg())
+        self.assertEqual(len(result1.index), 0)
+        self.assertIsInstance(result1["first"].dtype, TokenSpanDtype)
+        self.assertIsInstance(result1["second"].dtype, TokenSpanDtype)
+
+        result2 = overlap_join(self._make_join_arg(), self._make_empty_series())
+        self.assertEqual(len(result2.index), 0)
+        self.assertIsInstance(result2["first"].dtype, TokenSpanDtype)
+        self.assertIsInstance(result2["second"].dtype, TokenSpanDtype)
+
+        result3 = overlap_join(self._make_empty_series(), self._make_empty_series())
+        self.assertEqual(len(result3.index), 0)
+        self.assertIsInstance(result3["first"].dtype, TokenSpanDtype)
+        self.assertIsInstance(result3["second"].dtype, TokenSpanDtype)
+
+    def test_overlaps_join_empty_input_span_array(self):
+        # The previous test, but with character offsets instead of token offsets
+        result1 = overlap_join(self._make_empty_series_span_array(),
+                               self._make_join_arg())
+        self.assertEqual(len(result1.index), 0)
+        self.assertIsInstance(result1["first"].dtype, SpanDtype)
+        self.assertIsInstance(result1["second"].dtype, TokenSpanDtype)
+
+        result2 = overlap_join(self._make_empty_series_span_array(),
+                               self._make_join_arg())
+        self.assertEqual(len(result1.index), 0)
+        self.assertIsInstance(result1["first"].dtype, SpanDtype)
+        self.assertIsInstance(result1["second"].dtype, TokenSpanDtype)
+
+        result3 = overlap_join(self._make_empty_series_span_array(),
+                               self._make_empty_series_span_array())
+        self.assertEqual(len(result3.index), 0)
+        self.assertIsInstance(result3["first"].dtype, SpanDtype)
+        self.assertIsInstance(result3["second"].dtype, SpanDtype)
 
     def test_contain_join(self):
         join_arg = pd.Series(

--- a/text_extensions_for_pandas/util.py
+++ b/text_extensions_for_pandas/util.py
@@ -20,6 +20,7 @@
 #
 # Internal utility functions, not exposed in the public API.
 #
+from typing import Any
 
 import numpy as np
 from typing import *
@@ -65,3 +66,14 @@ class TestBase(unittest.TestCase):
                 f"   {a2}\n"
                 f"differ at positions: {np.argwhere(~mask)}"
             )
+
+
+def to_int_array(arr: Any) -> np.ndarray:
+    """
+    Turn an input into a Numpy array with an integer dtype, avoiding making a copy
+    if possible.
+    """
+    if isinstance(arr, np.ndarray) and np.issubdtype(arr.dtype, np.integer):
+        return arr  # Avoid making a copy even if the input is an unusual integer dtype
+    else:
+        return np.array(arr, dtype=np.int, copy=False)


### PR DESCRIPTION
The current implementation of `tp.spanner.overlap_join` crashes while computing shingle lengths if both inputs are empty. This PR fixes this problem.

I have added regression tests for the case that triggered the original crash, as well as a number of other combinations of empty/non-empty inputs, plus combinations of character-based and token-based span arrays.

I also encountered and fixed a minor bug in the way that the constructors for `SpanArray` and `TokenSpanArray` handle empty Python lists of begin and end offsets.