### PR TITLE
Add "first" reduction type and NA value to spans

### DIFF
--- a/text_extensions_for_pandas/array/span.py
+++ b/text_extensions_for_pandas/array/span.py
@@ -259,6 +259,14 @@ class SpanDtype(pd.api.extensions.ExtensionDtype):
         """
         return SpanArray
 
+    @property
+    def na_value(self) -> object:
+        """
+        See docstring in `ExtensionDType` class in `pandas/core/dtypes/base.py`
+        for information about this method.
+        """
+        return Span(None, Span.NULL_OFFSET_VALUE, Span.NULL_OFFSET_VALUE)
+
     def __from_arrow__(self, extension_array):
         """
         Convert the given extension array of type ArrowSpanType to a
@@ -672,6 +680,12 @@ class SpanArray(pd.api.extensions.ExtensionArray, SpanOpMixin):
             #         spans in the series
             return Span(self.target_text, np.min(self.begin),
                         np.max(self.end))
+        elif name == "first":
+            if 0 == len(self):
+                # TODO: Should we return None instead of null span here?
+                return Span(self.target_text, Span.NULL_OFFSET_VALUE,
+                            Span.NULL_OFFSET_VALUE)
+            return Span(self.target_text, self.begin[0], self.end[0])
         else:
             raise TypeError(f"'{name}' aggregation not supported on a series "
                             f"backed by a SpanArray")

--- a/text_extensions_for_pandas/array/test_span.py
+++ b/text_extensions_for_pandas/array/test_span.py
@@ -282,6 +282,7 @@ class CharSpanArrayTest(ArrayTestBase):
     def test_reduce(self):
         arr = self._make_spans_of_tokens()
         self.assertEqual(arr._reduce("sum"), Span(arr.target_text, 0, 14))
+        self.assertEqual(arr._reduce("first"), Span(arr.target_text, 0, 4))
         # Remind ourselves to modify this test after implementing min and max
         with self.assertRaises(TypeError):
             arr._reduce("min")

--- a/text_extensions_for_pandas/array/token_span.py
+++ b/text_extensions_for_pandas/array/token_span.py
@@ -217,6 +217,15 @@ class TokenSpanDtype(SpanDtype):
         """:return: A string representation of the dtype."""
         return "TokenSpanDtype"
 
+    @property
+    def na_value(self) -> object:
+        """
+        See docstring in `ExtensionDType` class in `pandas/core/dtypes/base.py`
+        for information about this method.
+        """
+        empty_span_array = SpanArray(None, [], [])
+        return TokenSpan(empty_span_array, Span.NULL_OFFSET_VALUE, Span.NULL_OFFSET_VALUE)
+
     @classmethod
     def construct_array_type(cls):
         """


### PR DESCRIPTION
This PR adds a "first" reduction (aka aggregate) to `SpanArray` and `TokenSpanArray`. I've also implemented the `na_value()` hook on the associated dtype classes, so that empty groups in a `groupby` expression will get a reasonable value.

There is still some work to be done in handling the case where someone tries to roll up a list of `Span` objects, some of which are null values with null target text and some of which aren't, into a single `SpanArray`. I think that problem is best handled in a follow-on PR.