### PR TITLE
Fixes for use with Pandas 1.2.1

### DIFF
--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -433,7 +433,7 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
     def __contains__(self, item) -> bool:
         if isinstance(item, TensorElement):
             npitem = np.asarray(item)
-            if npitem.size == 1 and  np.isnan(npitem).all():
+            if npitem.size == 1 and np.isnan(npitem).all():
                 return self.isna().any()
         return super().__contains__(item)
 


### PR DESCRIPTION
Fixed `_from_sequence` to handle np.nan, added `__contains__` to check for null values with text set to `None`.

Closes #168 