### PR TITLE
Adding NumPy ufunc to TensorArray

### DIFF
--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -22,6 +22,7 @@
 #
 
 from distutils.version import LooseVersion
+import numbers
 import os
 from typing import *
 
@@ -590,12 +591,17 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
             raise NotImplementedError(f"'{name}' aggregate not implemented.")
 
     def __array__(self, dtype=None):
-        print("ARRAY")
+        """
+        Interface to return the backing tensor as a numpy array with optional dtype.
+        If dtype is not None, then the tensor will be casted to that type, otherwise this is a no-op.
+        """
         return np.asarray(self._tensor, dtype=dtype)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        print("UFUNC")
-        import numbers
+        """
+        Interface to handle numpy ufuncs that will accept TensorArray as input, and wrap the output
+        back as another TensorArray.
+        """
         out = kwargs.get('out', ())
         for x in inputs + out:
             if not isinstance(x, (TensorArray, np.ndarray, numbers.Number)):

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -375,7 +375,10 @@ class TestTensor(unittest.TestCase):
 
         # Test as agg to TensorElement, defaults to axis=0
         result = s % 2 == 0
-        npt.assert_array_equal(result.all(), np.array([True, False]))
+        a = np.asarray(arr)
+        r = np.all(result.array, axis=1)
+        r = np.max(arr, axis=1)
+        #npt.assert_array_equal(result.all(), np.array([True, False]))
 
     def test_any(self):
         arr = TensorArray(np.arange(6).reshape(3, 2))

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -500,26 +500,32 @@ class TestTensor(unittest.TestCase):
         self.assertEqual(arr.inferred_type, "boolean")
 
     def test_numpy_ufunc(self):
+
+        def verify_ufunc_result(result_, expected_):
+            self.assertTrue(isinstance(result_, TensorArray))
+            npt.assert_array_equal(result_, expected_)
+
         data = np.arange(10).reshape(5, 2)
         arr = TensorArray(data)
 
         # ufunc with number
         result = np.add(arr, 1)
         expected = np.add(data, 1)
-        npt.assert_array_equal(result, expected)
-        self.assertTrue(isinstance(result, TensorArray))
+        verify_ufunc_result(result, expected)
+        result = np.add(1, arr)
+        verify_ufunc_result(result, expected)
 
         # ufunc with ndarray
         result = np.add(arr, data)
         expected = np.add(data, data)
-        npt.assert_array_equal(result, expected)
-        self.assertTrue(isinstance(result, TensorArray))
+        verify_ufunc_result(result, expected)
+        result = np.add(data, arr)
+        verify_ufunc_result(result, expected)
 
         # ufunc with another TensorArray
         result = np.add(arr, arr)
         expected = np.add(data, data)
-        npt.assert_array_equal(result, expected)
-        self.assertTrue(isinstance(result, TensorArray))
+        verify_ufunc_result(result, expected)
 
 
 class TensorArrayDataFrameTests(unittest.TestCase):

--- a/text_extensions_for_pandas/array/test_tensor.py
+++ b/text_extensions_for_pandas/array/test_tensor.py
@@ -375,10 +375,7 @@ class TestTensor(unittest.TestCase):
 
         # Test as agg to TensorElement, defaults to axis=0
         result = s % 2 == 0
-        a = np.asarray(arr)
-        r = np.all(result.array, axis=1)
-        r = np.max(arr, axis=1)
-        #npt.assert_array_equal(result.all(), np.array([True, False]))
+        npt.assert_array_equal(result.all(), np.array([True, False]))
 
     def test_any(self):
         arr = TensorArray(np.arange(6).reshape(3, 2))
@@ -501,6 +498,28 @@ class TestTensor(unittest.TestCase):
 
         arr = TensorArray([True, False, True])
         self.assertEqual(arr.inferred_type, "boolean")
+
+    def test_numpy_ufunc(self):
+        data = np.arange(10).reshape(5, 2)
+        arr = TensorArray(data)
+
+        # ufunc with number
+        result = np.add(arr, 1)
+        expected = np.add(data, 1)
+        npt.assert_array_equal(result, expected)
+        self.assertTrue(isinstance(result, TensorArray))
+
+        # ufunc with ndarray
+        result = np.add(arr, data)
+        expected = np.add(data, data)
+        npt.assert_array_equal(result, expected)
+        self.assertTrue(isinstance(result, TensorArray))
+
+        # ufunc with another TensorArray
+        result = np.add(arr, arr)
+        expected = np.add(data, data)
+        npt.assert_array_equal(result, expected)
+        self.assertTrue(isinstance(result, TensorArray))
 
 
 class TensorArrayDataFrameTests(unittest.TestCase):


### PR DESCRIPTION
This implements the `__array_ufunc` method in `TensorArray` for better integration with NumPy. When TensorArrays are used with numpy universal functions, such as `np.add()`, this method will be invoked to unwrap the inputs then wrap back the output as a TensorArray.