### PR TITLE
Add some missing extract ops

### DIFF
--- a/text_extensions_for_pandas/spanner/extract.py
+++ b/text_extensions_for_pandas/spanner/extract.py
@@ -246,8 +246,8 @@ def extract_regex(
     compiled_regex: re.Pattern
 ):
     """
-    Identify all non-overlapping matches of a regular expression, as returned by `
-    `regex.finditer()``, and return those locations as an array of spans.
+    Identify all non-overlapping matches of a regular expression, as returned by
+    ``re.Pattern.finditer()``, and return those locations as an array of spans.
 
     :param doc_text: Text of the document; will be the target text of the returned spans.
 

--- a/text_extensions_for_pandas/spanner/extract.py
+++ b/text_extensions_for_pandas/spanner/extract.py
@@ -243,7 +243,7 @@ def extract_regex_tok(
 
 def extract_regex(
     doc_text: str,
-    compiled_regex: re.Pattern
+    compiled_regex: "re.Pattern"  # Double quotes for Python 3.6 compatibility
 ):
     """
     Identify all non-overlapping matches of a regular expression, as returned by

--- a/text_extensions_for_pandas/spanner/extract.py
+++ b/text_extensions_for_pandas/spanner/extract.py
@@ -274,7 +274,7 @@ def extract_split(
     :param doc_text: Text of the document; will be the target text of the returned spans.
 
     :param split_points: A series of offsets into ``doc_text``, expressed as either:
-      * A sequence if integers (split at certain locations and return a set of splits that
+      * A sequence of integers (split at certain locations and return a set of splits that
         covers every character in the document) as a list or 1-d Numpy array
       * A sequence of spans (split around the indicated locations, but discard the parts
         of the document that are within a split point)

--- a/text_extensions_for_pandas/spanner/extract.py
+++ b/text_extensions_for_pandas/spanner/extract.py
@@ -19,6 +19,8 @@
 # Variants of the Extract operator from spanner algebra. The Extract operator
 # returns sub-spans of a parent span that match a predicate.
 #
+import collections
+import re
 
 import numpy as np
 import pandas as pd
@@ -27,7 +29,7 @@ import regex
 from typing import *
 
 # Internal imports
-from text_extensions_for_pandas.array.span import SpanArray
+from text_extensions_for_pandas.array.span import SpanArray, Span
 from text_extensions_for_pandas.array.token_span import TokenSpanArray
 from text_extensions_for_pandas.io.spacy import simple_tokenizer
 
@@ -202,7 +204,7 @@ def extract_regex_tok(
     Identify all (possibly overlapping) matches of a regular expression
     that start and end on token boundaries.
 
-    :param tokens: `SpanArray` of token information, optionally wrapped in a
+    :param tokens: ``SpanArray`` of token information, optionally wrapped in a
     `pd.Series`.
 
     :param compiled_regex: Regular expression to evaluate.
@@ -237,3 +239,76 @@ def extract_regex_tok(
             pd.Series(window_tok_spans[matches_regex_f(window_tok_spans.covered_text)])
         )
     return pd.DataFrame({output_col_name: pd.concat(matches_list)})
+
+
+def extract_regex(
+    doc_text: str,
+    compiled_regex: re.Pattern
+):
+    """
+    Identify all non-overlapping matches of a regular expression, as returned by `
+    `regex.finditer()``, and return those locations as an array of spans.
+
+    :param doc_text: Text of the document; will be the target text of the returned spans.
+
+    :param compiled_regex: Regular expression to evaluate, compiled with either the ``re``
+      or the ``regex`` package.
+
+    :returns: A ``SpanArray`` containing a span for each match of the regex.
+    """
+    begins = []
+    ends = []
+    for a in compiled_regex.finditer(doc_text):
+        begins.append(a.start())
+        ends.append(a.end())
+
+    return SpanArray(doc_text, begins, ends)
+
+
+def extract_split(
+    doc_text: str, split_points: Union[Sequence[int], np.ndarray, SpanArray]
+) -> SpanArray:
+    """
+    Split a document into spans along a specified set of split points.
+
+    :param doc_text: Text of the document; will be the target text of the returned spans.
+
+    :param split_points: A series of offsets into ``doc_text``, expressed as either:
+      * A sequence if integers (split at certain locations and return a set of splits that
+        covers every character in the document) as a list or 1-d Numpy array
+      * A sequence of spans (split around the indicated locations, but discard the parts
+        of the document that are within a split point)
+
+    :returns: An ``SpanArray``  that splits the document in the specified way.
+    """
+    if isinstance(split_points, (collections.Sequence, np.ndarray)):
+        # Single-integer split points ==> zero-length spans
+        split_points = SpanArray(doc_text, split_points, split_points)
+    elif not isinstance(split_points, SpanArray):
+        raise TypeError(f"Split points are of type {type(split_points)}. Expected a "
+                        f"sequence of integers or a SpanArray.")
+
+    # Make sure split points are in order
+    sorted_indices = split_points.argsort()
+    sorted_split_points = split_points[sorted_indices]
+
+    # Break out the split points.
+    split_begins = sorted_split_points.begin.tolist()  # type: List[int]
+    split_ends = sorted_split_points.end.tolist()  # type: List[int]
+
+    # Tack on an additional split point at the very end to simplify the logic below.
+    split_begins.append(len(doc_text))
+    split_ends.append(len(doc_text))
+
+    # Walk through the document, generating the begin and end offsets of spans
+    begins = []
+    ends = []
+    begin = 0
+    for split_begin, split_end in zip(split_begins, split_ends):
+        end = split_begin
+        if end > begin:  # Ignore zero-length and negative-length chunks
+            begins.append(begin)
+            ends.append(end)
+        begin = split_end
+
+    return SpanArray(doc_text, begins, ends)

--- a/text_extensions_for_pandas/spanner/test_extract.py
+++ b/text_extensions_for_pandas/spanner/test_extract.py
@@ -22,10 +22,10 @@ from text_extensions_for_pandas.util import TestBase
 
 
 class ExtractTest(TestBase):
-
     @staticmethod
     def _make_tokenizer():
         from spacy.lang.en import English
+
         nlp = English()
         return nlp.tokenizer
 
@@ -33,7 +33,9 @@ class ExtractTest(TestBase):
     def _read_file(file_name):
         with open(file_name, "r") as f:
             lines = [
-                line.strip() for line in f.readlines() if len(line) > 0 and line[0] != "#"
+                line.strip()
+                for line in f.readlines()
+                if len(line) > 0 and line[0] != "#"
             ]
         return " ".join(lines)
 
@@ -50,16 +52,17 @@ class ExtractTest(TestBase):
                 2        help     me       !        i     am  trapped   None
                 3          in      a   haiku  factory      !     None   None
                 4        save     me  before     they   None     None   None"""
-            )
+            ),
         )
 
     def test_create_dict(self):
-        entries = ["Dictionary Entry",
-                   "Entry",
-                   "Help me! I am trapped",
-                   "In a Haiku factory!",
-                   "Save me before they",
-                   ]
+        entries = [
+            "Dictionary Entry",
+            "Entry",
+            "Help me! I am trapped",
+            "In a Haiku factory!",
+            "Save me before they",
+        ]
         df = create_dict(entries)
         # print(f"***{df}***")
         self.assertEqual(
@@ -72,7 +75,7 @@ class ExtractTest(TestBase):
                 2        help     me       !        i     am  trapped   None
                 3          in      a   haiku  factory      !     None   None
                 4        save     me  before     they   None     None   None"""
-            )
+            ),
         )
 
     def test_extract_dict(self):
@@ -99,7 +102,7 @@ class ExtractTest(TestBase):
                 5  [23, 44): 'Help me! I am trapped'
                 4    [45, 64): 'In a Haiku factory!'
                 3    [65, 84): 'Save me before they'"""
-            )
+            ),
         )
 
     def test_extract_regex_tok(self):
@@ -125,7 +128,7 @@ class ExtractTest(TestBase):
                 2      [17, 22): 'Entry'
                 3    [56, 63): 'factory'
                 4       [80, 84): 'they'"""
-            )
+            ),
         )
 
     def test_extract_regex_tok_len_2(self):
@@ -137,8 +140,9 @@ class ExtractTest(TestBase):
 
         match_regex = re.compile(r".*y$")
 
-        result_df = extract_regex_tok(char_span, match_regex, min_len=2, max_len=2,
-                                      output_col_name="result")
+        result_df = extract_regex_tok(
+            char_span, match_regex, min_len=2, max_len=2, output_col_name="result"
+        )
 
         self.assertIn("result", result_df.columns)
         # print(f"****\n{result_df}\n****")
@@ -151,5 +155,103 @@ class ExtractTest(TestBase):
                 1      [11, 22): 'Entry Entry'
                 2    [50, 63): 'Haiku factory'
                 3      [73, 84): 'before they'"""
-            )
+            ),
+        )
+
+    def test_extract_regex(self):
+        file_name = "test_data/io/test_systemt/test.dict"
+        file_text = self._read_file(file_name)
+
+        match_regex = re.compile(r"[A-Z][^y]+y")
+
+        result = extract_regex(file_text, match_regex)
+        self.assertEqual(
+            repr(result),
+            textwrap.dedent(
+                """\
+                <SpanArray>
+                [                               [0, 10): 'Dictionary',
+                                                    [11, 16): 'Entry',
+                                                    [17, 22): 'Entry',
+                 [23, 63): 'Help me! I am trapped In a Haiku factory',
+                                      [65, 84): 'Save me before they']
+                Length: 5, dtype: SpanDtype"""
+            ),
+        )
+
+    def test_extract_split(self):
+        doc_text = "This is a test. This is also a test."
+
+        offsets_1 = [15, 20]  # Split in the middle
+        result_1 = extract_split(doc_text, offsets_1)
+        self.assertEqual(
+            repr(result_1),
+            textwrap.dedent(
+                """\
+                <SpanArray>
+                [[0, 15): 'This is a test.', [15, 20): 'This', [20, 36): 'is also a test.']
+                Length: 3, dtype: SpanDtype"""
+            ),
+        )
+
+        # ndarray instead of list
+        offsets_1a = np.array(offsets_1)
+        result_1a = extract_split(doc_text, offsets_1a)
+        self.assertTrue(result_1.equals(result_1a))
+
+        # Split at the edges
+        offsets_2 = [0, 10, len(doc_text)]
+        result_2 = extract_split(doc_text, offsets_2)
+        self.assertEqual(
+            repr(result_2),
+            textwrap.dedent(
+                """\
+                <SpanArray>
+                [[0, 10): 'This is a', [10, 36): 'test. This is also a test.']
+                Length: 2, dtype: SpanDtype"""
+            ),
+        )
+
+        # Duplicate splits
+        offsets_3 = [15, 15]
+        result_3 = extract_split(doc_text, offsets_3)
+        self.assertEqual(
+            repr(result_3),
+            textwrap.dedent(
+                """\
+                <SpanArray>
+                [[0, 15): 'This is a test.', [15, 36): 'This is also a test.']
+                Length: 2, dtype: SpanDtype"""
+            ),
+        )
+
+        # Split on spans, not offsets
+        offsets_4 = SpanArray(doc_text, [15, 20], [16, 24])
+        result_4 = extract_split(doc_text, offsets_4)
+        self.assertEqual(
+            repr(result_4),
+            textwrap.dedent(
+                """\
+                <SpanArray>
+                [[0, 15): 'This is a test.', [16, 20): 'This', [24, 36): 'also a test.']
+                Length: 3, dtype: SpanDtype"""
+            ),
+        )
+
+        # Spans out of order
+        offsets_5 = SpanArray(doc_text, [20, 15], [24, 16])
+        result_5 = extract_split(doc_text, offsets_5)
+        self.assertTrue(result_5.equals(result_4))
+
+        # Split on regex
+        offsets_6 = extract_regex(doc_text, re.compile("This"))
+        result_6 = extract_split(doc_text, offsets_6)
+        self.assertEqual(
+            repr(result_6),
+            textwrap.dedent(
+                """\
+                <SpanArray>
+                [[4, 16): 'is a test.', [20, 36): 'is also a test.']
+                Length: 2, dtype: SpanDtype"""
+            ),
         )


### PR DESCRIPTION
While working on a blog post, I noticed that we are missing some variants of the `extract` operator from spanner algebra:
* `extract_regex`: return all matches of a character-based regex
* `extract_split`: Split the document into spans according to a set of split points

This PR implements those two operations and adds appropriate tests.