### PR TITLE
SpanArray HTML rendering interactivity and view instance tools

### DIFF
--- a/text_extensions_for_pandas/jupyter.py
+++ b/text_extensions_for_pandas/jupyter.py
@@ -150,14 +150,14 @@ def pretty_print_html(column: Union["SpanArray", "TokenSpanArray"],
     show_offset_string = 'true' if show_offsets else 'false'
     
     return textwrap.dedent(f"""
+        <style class="span-array-css">
+            {textwrap.indent(style_text, '        ')}
+        </style>
         <script>
         {{
             {textwrap.indent(script_text, '        ')}
         }}
         </script>
-        <style>
-            {textwrap.indent(style_text, '        ')}
-        </style>
         <div class="span-array">
             If you're reading this message, your notebook viewer does not support Javascript execution. Try pasting the URL into a service like nbviewer.
         </div>

--- a/text_extensions_for_pandas/resources/span_array.css
+++ b/text_extensions_for_pandas/resources/span_array.css
@@ -25,31 +25,6 @@
     --fallback-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif
 }
 
-/* These 2 CSS block sets variable overrides for JupyterLab's default themes */
-/*
-body[data-jp-theme-name="JupyterLab Dark"] .span-array {
-    --thead-background-color: #144552;
-    --thead-text-color: whitesmoke;
-    --tbody-background-color-1: #0B525B;
-    --tbody-background-color-2: #065A60;
-    --tbody-background-color-hover: #197072;
-    --tbody-background-color-disabled: #486669;
-    --tbody-text-color: rgb(243, 243, 243);
-    --paragraph-border-color: #1b1b1b;
-}
-
-body[data-jp-theme-name="JupyterLab Light"] .span-array {
-    --thead-background-color: #0d2025;
-    --thead-text-color: whitesmoke;
-    --tbody-background-color-1: #f0f0f0;
-    --tbody-background-color-2: #ececec;
-    --tbody-background-color-hover: #6fd9db;
-    --tbody-background-color-disabled: #9c9c9c;
-    --tbody-text-color: rgb(0, 0, 0);
-    --paragraph-border-color: #f1f1f1;
-}
-*/
-
 /* Table of span offsets */
 .span-array>.document>table {
     table-layout: auto;

--- a/text_extensions_for_pandas/resources/span_array.css
+++ b/text_extensions_for_pandas/resources/span_array.css
@@ -1,11 +1,12 @@
 .span-array {
-    --thead-background-color: var(--jp-layout-color4, inherit);
-    --thead-text-color: var(--jp-ui-font-color4);
-    --tbody-background-color-1: var(--jp-layout-color2, inherit);
-    --tbody-background-color-2: var(--jp-layout-color1, inherit);
-    --tbody-background-color-hover: var(--jp-layout-color3, inherit);
+    --thead-background-color: var(--jp-layout-color1, inherit);
+    --thead-text-color: var(--jp-ui-font-color1, inherit);
+    --tbody-background-color-1: var(--jp-layout-color1, inherit);
+    --tbody-background-color-2: var(--jp-layout-color2, inherit);
+    --tbody-background-color-hover: var(--jp-rendermime-table-row-hover-background, var(--jp-layout-color3, inherit));
     --tbody-background-color-disabled: var(--jp-layout-color4, inherit);
     --tbody-text-color: var(--jp-ui-font-color0, inherit);
+    --tbody-text-color-disabled: var(--jp-ui-inverse-font-color0, inherit);
     --table-font-family: var(--jp-content-font-family, var(--fallback-font-family, inherit));
 
     --root-highlight: #a0c4ff;
@@ -20,6 +21,7 @@
 }
 
 /* These 2 CSS block sets variable overrides for JupyterLab's default themes */
+/*
 body[data-jp-theme-name="JupyterLab Dark"] .span-array {
     --thead-background-color: #144552;
     --thead-text-color: whitesmoke;
@@ -41,11 +43,11 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
     --tbody-text-color: rgb(0, 0, 0);
     --paragraph-border-color: #f1f1f1;
 }
+*/
 
 /* Table of span offsets */
 .span-array>.document>table {
     table-layout: auto;
-    border-radius: 1em 1em 0 0;
     overflow: hidden;
     width: 100%;
     border-collapse: collapse;
@@ -64,7 +66,6 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
 
 .span-array>.document>table>tbody>tr:nth-child(2n+1) {
     background-color: var(--tbody-background-color-1);
-    color: var(--tbody-text-color);
 }
 
 .span-array>.document>table>tbody>tr:nth-child(2n) {
@@ -82,6 +83,18 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
 
 .span-array>.document>table tr>td:not(tr>td:last-child), .span-array>.document>table tr>th:not(tr>th:last-child) {
     text-align: left;
+}
+
+.span-array>.document>table tr.hover:nth-child(n) {
+    background-color: var(--tbody-background-color-hover);
+}
+
+.span-array>.document>table tr.disabled:nth-child(n), .span-array>.document>table tr.disabled.hover:nth-child(n) {
+    background-color: var(--tbody-background-color-disabled);
+}
+
+.span-array>.document>table tr.disabled:nth-child(n)>td, .span-array>.document>table tr.disabled.hover:nth-child(n)>td {
+    color: var(--tbody-text-color-disabled);
 }
 
 /* Styling for spans within document context */
@@ -125,4 +138,9 @@ body[data-jp-theme-light="false"].span-array>.document>p {
     font-variant-caps: all-small-caps;
     margin-left: 8px;
     text-transform: uppercase;
+}
+
+.span-array>.document>p mark.hover, .span-array.span-array>.document>p mark>mark.hover, .span-array>.document>p mark.complex-set.hover {
+    background: none;
+    background-color: var(--hover-highlight);
 }

--- a/text_extensions_for_pandas/resources/span_array.css
+++ b/text_extensions_for_pandas/resources/span_array.css
@@ -9,6 +9,11 @@
     --tbody-text-color-disabled: var(--jp-ui-inverse-font-color0, #b3b3b9);
     --table-font-family: var(--jp-content-font-family, var(--fallback-font-family, inherit));
 
+    --table-control-background: rgba(0, 0, 0, 0.2);
+    --table-control-color: var(--jp-ui-font-color0);
+    --table-control-border: 1px solid rgba(0, 0, 0, 0.8);
+    --table-control-border-radius: 0.5em;
+
     --root-highlight: #a0c4ff;
     --nested-highlight: #ffadad;
     --hover-highlight: #ffd6a5;
@@ -75,11 +80,11 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
 .span-array>.document>table td {
     padding: 0.5em;
     color: var(--tbody-text-color);
-    cursor: pointer;
 }
 
 .span-array>.document>table tr>td:last-child, .span-array>.document>table tr>th:last-child {
     text-align: right;
+    width: 100%;
 }
 
 .span-array>.document>table tr>td:not(tr>td:last-child), .span-array>.document>table tr>th:not(tr>th:last-child) {
@@ -96,6 +101,50 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
 
 .span-array>.document>table tr.disabled:nth-child(n)>td, .span-array>.document>table tr.disabled.hover:nth-child(n)>td {
     color: var(--tbody-text-color-disabled);
+}
+
+/* Table control buttons */
+
+.span-array>.document>table td:first-child {
+    vertical-align: center;
+}
+
+.span-array>.document>table td:first-child>div.sa-table-controls {
+    display: flex;
+    flex-direction: row;
+}
+
+.span-array>.document>table td:first-child button {
+    background-color: var(--table-control-background);
+    color: var(--table-control-color);
+    border: var(--table-control-border);
+    border-right: none;
+    border-radius: 0;
+    cursor: pointer;
+}
+
+.span-array>.document>table td:first-child button:first-child {
+    border-radius: var(--table-control-border-radius) 0 0 var(--table-control-border-radius);
+}
+
+.span-array>.document>table td:first-child button:last-child {
+    border-radius: 0 var(--table-control-border-radius) var(--table-control-border-radius) 0;
+    border-right: var(--table-control-border);
+}
+
+.span-array>.document>table td:first-child button[data-control="visibility"]:hover {
+    background-color: var(--root-highlight);
+    color: black;
+}
+
+.span-array>.document>table tr:not(tr.disabled) td:first-child button[data-control="highlight"]:hover {
+    background-color: var(--hover-highlight);
+    color: black;
+}
+
+.span-array>.document>table tr.highlighted:not(tr.disabled) td:first-child button[data-control="highlight"] {
+    background-color: var(--hover-highlight);
+    color: black;
 }
 
 /* Styling for spans within document context */

--- a/text_extensions_for_pandas/resources/span_array.css
+++ b/text_extensions_for_pandas/resources/span_array.css
@@ -4,9 +4,9 @@
     --tbody-background-color-1: var(--jp-layout-color1, inherit);
     --tbody-background-color-2: var(--jp-layout-color2, inherit);
     --tbody-background-color-hover: var(--jp-rendermime-table-row-hover-background, var(--jp-layout-color3, inherit));
-    --tbody-background-color-disabled: var(--jp-layout-color4, inherit);
+    --tbody-background-color-disabled: var(--jp-layout-color4, #ccccd1);
     --tbody-text-color: var(--jp-ui-font-color0, inherit);
-    --tbody-text-color-disabled: var(--jp-ui-inverse-font-color0, inherit);
+    --tbody-text-color-disabled: var(--jp-ui-inverse-font-color0, #b3b3b9);
     --table-font-family: var(--jp-content-font-family, var(--fallback-font-family, inherit));
 
     --root-highlight: #a0c4ff;
@@ -15,7 +15,7 @@
 
     --inverted-background-color: #0B525B;
     --inverted-text-color: rgb(243, 243, 243);
-    --paragraph-border-color: transparent;
+    --paragraph-border-color: var(--jp-layout-color2, inherit);
 
     --fallback-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif
 }
@@ -74,7 +74,8 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
 
 .span-array>.document>table td {
     padding: 0.5em;
-    color: var(--tbody-text-color)
+    color: var(--tbody-text-color);
+    cursor: pointer;
 }
 
 .span-array>.document>table tr>td:last-child, .span-array>.document>table tr>th:last-child {
@@ -85,7 +86,7 @@ body[data-jp-theme-name="JupyterLab Light"] .span-array {
     text-align: left;
 }
 
-.span-array>.document>table tr.hover:nth-child(n) {
+.span-array>.document>table tr.hover:nth-child(n), .span-array>.document>table tr.highlighted:nth-child(n) {
     background-color: var(--tbody-background-color-hover);
 }
 
@@ -116,6 +117,7 @@ body[data-jp-theme-light="false"].span-array>.document>p {
 .span-array>.document>p mark {
     padding: 0.4em 0.4em;
     border-radius: 0.35em;
+    cursor: pointer;
 }
 
 .span-array>.document>p mark {
@@ -140,7 +142,7 @@ body[data-jp-theme-light="false"].span-array>.document>p {
     text-transform: uppercase;
 }
 
-.span-array>.document>p mark.hover, .span-array.span-array>.document>p mark>mark.hover, .span-array>.document>p mark.complex-set.hover {
+.span-array>.document>p mark.hover, .span-array.span-array>.document>p mark>mark.hover, .span-array>.document>p mark.complex-set.hover, .span-array>.document>p mark.highlighted, .span-array>.document>p mark.complex-set.highlighted, .span-array.span-array>.document>p mark>mark.highlighted {
     background: none;
     background-color: var(--hover-highlight);
 }

--- a/text_extensions_for_pandas/resources/span_array.js
+++ b/text_extensions_for_pandas/resources/span_array.js
@@ -22,10 +22,10 @@ if(window.SpanArray == undefined || window.SpanArray.VERSION == undefined || win
     window.SpanArray.TYPE_COMPLEX = 2;
     window.SpanArray.TYPE_SOLO = 3;
 
-    TYPE_OVERLAP = window.SpanArray.TYPE_OVERLAP;
-    TYPE_NESTED = window.SpanArray.TYPE_NESTED;
-    TYPE_COMPLEX = window.SpanArray.TYPE_COMPLEX;
-    TYPE_SOLO = window.SpanArray.TYPE_SOLO;
+    const TYPE_OVERLAP = window.SpanArray.TYPE_OVERLAP;
+    const TYPE_NESTED = window.SpanArray.TYPE_NESTED;
+    const TYPE_COMPLEX = window.SpanArray.TYPE_COMPLEX;
+    const TYPE_SOLO = window.SpanArray.TYPE_SOLO;
 
     function sanitize(input) {
         let out = input.slice();

--- a/text_extensions_for_pandas/resources/span_array.js
+++ b/text_extensions_for_pandas/resources/span_array.js
@@ -1,11 +1,11 @@
 // Increment the version to invalidate the cached script
 const VERSION = 0.75
+const global_stylesheet = document.head.querySelector("style.span-array-css")
+const local_stylesheet = document.currentScript.parentElement.querySelector("style.span-array-css")
 
 if(window.SpanArray == undefined || window.SpanArray.VERSION == undefined || window.SpanArray.VERSION < VERSION) {
 
     // Replace global SpanArray CSS with latest copy
-    const global_stylesheet = document.head.querySelector("style.span-array-css")
-    const local_stylesheet = document.currentScript.parentElement.querySelector("style.span-array-css")
     if(local_stylesheet != undefined) {
         if(global_stylesheet != undefined) {
             document.head.removeChild(global_stylesheet)
@@ -385,17 +385,18 @@ if(window.SpanArray == undefined || window.SpanArray.VERSION == undefined || win
             if(closest_tr == undefined) return
 
             const matching_span = doc_object.lookup_table[closest_tr.getAttribute("data-id")]
+            if(matching_span == undefined) return
 
             switch(closest_control_button.getAttribute("data-control")) {
                 case "visibility":
                     {
-                        if(matching_span != undefined) matching_span.visible = !matching_span.visible
+                        matching_span.visible = !matching_span.visible
                         source_spanarray.render()
                     }
                     break;
                 case "highlight":
                     {
-                        if(matching_span != undefined) matching_span.highlighted = !matching_span.highlighted
+                        matching_span.highlighted = !matching_span.highlighted
                         source_spanarray.render()
                     }
                     break;
@@ -437,9 +438,7 @@ if(window.SpanArray == undefined || window.SpanArray.VERSION == undefined || win
 } else {
     // SpanArray JS is already defined and not an outdated copy
     // Replace global SpanArray CSS with latest copy IFF global stylesheet is undefined
-
-    const global_stylesheet = document.head.querySelector("style.span-array-css")
-    const local_stylesheet = document.currentScript.parentElement.querySelector("style.span-array-css")
+    
     if(local_stylesheet != undefined) {
         if(global_stylesheet == undefined) {
             document.head.appendChild(local_stylesheet)

--- a/text_extensions_for_pandas/resources/span_array.js
+++ b/text_extensions_for_pandas/resources/span_array.js
@@ -1,5 +1,5 @@
 // Increment the version to invalidate the cached script
-const VERSION = 0.738
+const VERSION = 0.74
 
 if(!window.SpanArray || window.SpanArray.VERSION < VERSION) {
 
@@ -231,8 +231,6 @@ if(!window.SpanArray || window.SpanArray.VERSION < VERSION) {
             }
         }
 
-        console.log(highlight_regions)
-
         let paragraph = document.createElement("p")
         if(highlight_regions.length == 0) {
             paragraph.textContent = doc_text
@@ -353,6 +351,7 @@ if(!window.SpanArray || window.SpanArray.VERSION < VERSION) {
         // Click disable/enable events
 
         doc_table_body.addEventListener("click", (event) => {
+            // Only listen to left button clicks on or within a table row.
             const closest_tr = event.target.closest("tr")
             if(closest_tr == undefined) return
 
@@ -363,6 +362,37 @@ if(!window.SpanArray || window.SpanArray.VERSION < VERSION) {
             if(matching_span != undefined) matching_span.visible = !matching_span.visible
             source_spanarray.render()
         }, true)
+
+        doc_text.addEventListener("click", (event) => {
+            const closest_mark = event.target.closest("mark")
+            if(closest_mark == undefined) return
+
+            if(closest_mark.classList.contains("highlighted")) {
+                closest_mark.classList.remove("highlighted")
+    
+                const ids = closest_mark.getAttribute("data-ids").split(",").slice(0, -1)
+                ids.map(id => {
+                    return id.substring(1)
+                })
+                .forEach(id => {
+                    const row = doc_table_body.querySelector(`tr[data-id="${id}"]`)
+                    row.classList.remove("highlighted")
+                })
+
+            } else {
+                closest_mark.classList.add("highlighted")
+    
+                const ids = closest_mark.getAttribute("data-ids").split(",").slice(0, -1)
+                ids.map(id => {
+                    return id.substring(1)
+                })
+                .forEach(id => {
+                    const row = doc_table_body.querySelector(`tr[data-id="${id}"]`)
+                    row.classList.add("highlighted")
+                })
+            }
+
+        })
     }
 } else {
     // SpanArray JS is already defined and not an outdated copy

--- a/text_extensions_for_pandas/resources/span_array.js
+++ b/text_extensions_for_pandas/resources/span_array.js
@@ -1,7 +1,7 @@
 // Increment the version to invalidate the cached script
 const VERSION = 0.75
 
-if(!window.SpanArray || window.SpanArray.VERSION < VERSION) {
+if(window.SpanArray == undefined || window.SpanArray.VERSION == undefined || window.SpanArray.VERSION < VERSION) {
 
     // Replace global SpanArray CSS with latest copy
     const global_stylesheet = document.head.querySelector("style.span-array-css")


### PR DESCRIPTION
For issue #202

Added interactivity to the JS-generated HTML rendering of SpanArrays and TokenSpanArrays, including table controls like visibility toggling and highlight locking. 

Removed JupyterLab-specific CSS overrides in favor of more consistent styling across themes, and made some general styling adjustments.

Added highlights as a view instance property, preserving highlight locks over multiple view renders, but isolating the locks to the instance (Multiple JPL windows of the same notebook can have separate Spans hidden or highlighted at the same time).

Compatibility verified in JupyterLab and VSCode