### PR TITLE
Add pip to initial environment contents

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -111,7 +111,7 @@ if [ -n "${ENV_NAME}" ]; then
     # Remove the detrius of any previous runs of this script
     conda env remove -n ${ENV_NAME}
 
-    conda create -y --name ${ENV_NAME} python=${PYTHON_VERSION}
+    conda create -y --name ${ENV_NAME} python=${PYTHON_VERSION} pip
 
     ################################################################################
     # All the installation steps that follow must be done from within the new


### PR DESCRIPTION
Recent versions of Anaconda don't install `pip` by default in new environments. This causes problems when our environment setup script tries to run `pip install` from inside a newly-created environment. This PR adds `pip` to the initial environment contents to fix this problem.