### PR TITLE
Remove version check from workaround for Pandas #42430

### DIFF
--- a/text_extensions_for_pandas/array/tensor.py
+++ b/text_extensions_for_pandas/array/tensor.py
@@ -542,8 +542,7 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
                 return TensorElement(value)
         else:
             # BEGIN workaround for Pandas issue #42430
-            if (pd.__version__ == "1.3.0" and isinstance(item, tuple) and len(item) > 1
-                    and item[0] == Ellipsis):
+            if isinstance(item, tuple) and len(item) > 1 and item[0] == Ellipsis:
                 if len(item) > 2:
                     # Hopefully this case is not possible, but can't be sure
                     raise ValueError(f"Workaround Pandas issue #42430 not implemented "


### PR DESCRIPTION
The discussion around https://github.com/pandas-dev/pandas/issues/42430 is taking longer than expected. Pandas has released a 1.3.1 release without a fix for this issue. From the direction the discussion is taking, it looks like further performance related changes are likely to introduce similar breakage in the future, even after this issue is patched.

This PR removes the Pandas version check from the workaround from this issue. That way we won't be broken if Pandas decides to put the offending performance code into another future release. Due to the other checks that are still done, the workaround is still only activated in a narrow set of circumstances even after this change.