### PR TITLE
Update Python version for CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.11, 3.12]
         # Test against older version(s) of Pandas and latest version
         pandas-version: ["2.2.*", ""]
         #exclude:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,13 +19,12 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11, 3.12, 3.13]
-        # Test against Pandas 1.3 and latest version
-        #pandas-version: ["1.3.*", ""]
-        pandas-version: ["1.3.*"]
-        exclude:
-          # Exclude combinations we don't expect to occur due to release dates
-          - python-version: 3.13
-            pandas-version: "1.3.*"
+        # Test against older version(s) of Pandas and latest version
+        pandas-version: ["2.2.*", ""]
+        #exclude:
+          # Uncomment to exclude combinations we don't expect to work
+          # - python-version: 3.13
+          #   pandas-version: "1.3.*"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,19 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        # Test against Pandas 1.2, 1.3, and latest version
-        pandas-version: ["1.2.*", "1.3.*", ""]
+        python-version: [3.11, 3.12, 3.13]
+        # Test against Pandas 1.3 and latest version
+        pandas-version: ["1.3.*", ""]
         exclude:
-          # Test all Pandas versions with Python 3.8, exclude others
-          - python-version: 3.7
-            pandas-version: "1.1.*"
-          - python-version: 3.7
-            pandas-version: "1.2.*"
-          - python-version: 3.8
-            pandas-version: "1.1.*"
-          - python-version: 3.8
-            pandas-version: "1.2.*"
+          # Exclude combinations we don't expect to occur due to release dates
+          - python-version: 3.13
+            pandas-version: "1.3.*"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,8 @@ jobs:
       matrix:
         python-version: [3.11, 3.12, 3.13]
         # Test against Pandas 1.3 and latest version
-        pandas-version: ["1.3.*", ""]
+        #pandas-version: ["1.3.*", ""]
+        pandas-version: ["1.3.*"]
         exclude:
           # Exclude combinations we don't expect to occur due to release dates
           - python-version: 3.13

--- a/config/dev_reqs.txt
+++ b/config/dev_reqs.txt
@@ -7,7 +7,7 @@ pytest
 pyyaml
 transformers>=3.0.0
 # SpaCy models aren't stable across point releases
-spacy==3.6.0
+spacy>=3.7.0,<3.8
 ipywidgets
 ibm-watson
 twine

--- a/env.sh
+++ b/env.sh
@@ -12,7 +12,7 @@
 # Use environment variables if present.
 # (-z predicate means "unset or empty string")
 if [ -z "$PYTHON_VERSION" ]; then
-    PYTHON_VERSION="3.8"
+    PYTHON_VERSION="3.13"
 fi
 ENV_NAME="pd"
 

--- a/env.sh
+++ b/env.sh
@@ -12,7 +12,7 @@
 # Use environment variables if present.
 # (-z predicate means "unset or empty string")
 if [ -z "$PYTHON_VERSION" ]; then
-    PYTHON_VERSION="3.13"
+    PYTHON_VERSION="3.12"
 fi
 ENV_NAME="pd"
 


### PR DESCRIPTION
This PR updates the versions of Python we use in the CI flows, so as to unblock #251 